### PR TITLE
Read pin depends

### DIFF
--- a/cli/init.ml
+++ b/cli/init.ml
@@ -44,7 +44,13 @@ let run (`Repo repo)
   let open Rresult.R.Infix in
   init_local_opam_repo opam_repo >>= fun local_opam_repo ->
   Opam_cmd.find_local_opam_packages repo >>= fun local_paths ->
-  Pins.read_from_config Fpath.(repo // Config.duniverse_file) >>= fun pins ->
+
+  Pins.read_from_config Fpath.(repo // Config.duniverse_file) >>= fun config_pins ->
+  let opam_pin_depends =
+    String.Map.fold (fun _ opam_file acc -> acc @ Pins.read_from_opam opam_file) local_paths [] in
+  (* TODO: What if we have duplicates? *)
+  let pins = config_pins @ opam_pin_depends in
+
   let local_packages = List.map fst (String.Map.bindings local_paths) in
   build_config ~local_packages ~pins ~pull_mode ~opam_repo
   >>= fun config ->

--- a/cli/init.ml
+++ b/cli/init.ml
@@ -44,13 +44,7 @@ let run (`Repo repo)
   let open Rresult.R.Infix in
   init_local_opam_repo opam_repo >>= fun local_opam_repo ->
   Opam_cmd.find_local_opam_packages repo >>= fun local_paths ->
-
-  Pins.read_from_config Fpath.(repo // Config.duniverse_file) >>= fun config_pins ->
-  let opam_pin_depends =
-    String.Map.fold (fun _ opam_file acc -> acc @ Pins.read_from_opam opam_file) local_paths [] in
-  (* TODO: What if we have duplicates? *)
-  let pins = config_pins @ opam_pin_depends in
-
+  Pins.read ~opam_files:local_paths ~config:Fpath.(repo // Config.duniverse_file) >>= fun pins ->
   let local_packages = List.map fst (String.Map.bindings local_paths) in
   build_config ~local_packages ~pins ~pull_mode ~opam_repo
   >>= fun config ->

--- a/lib/pins.ml
+++ b/lib/pins.ml
@@ -29,8 +29,9 @@ let read_from_opam opam_file =
       let url = Some Uri.(with_fragment url None |> to_string) in
       begin
         match String.cut ~sep:"." pkg_nv with
-        | Some (pin, "") -> Some { Types.Opam.pin; tag; url }
-        | Some (pin, tag) -> Some { pin; tag = Some tag; url }
+        | Some (pin, ("" | "dev")) -> Some { Types.Opam.pin; tag; url }
+        | Some (pin, version) when tag = None -> Some { pin; tag = Some version; url }
+        | Some (pin, version) -> Some { pin; tag = Some version; url }
         | None -> None
       end
     | _ -> None


### PR DESCRIPTION
Adds the ability to read pins from the `pin-depends` field in the root opam files during `init`.

This is IMO a more convenient way to keep track of pins as they don't have to be manually added with the `duniverse pin` command. (I currently add them in a Makefile which I don't particularly like.)

Having two sources of pins means that there might be conflicts. For example, what should happen if `dune-get` has a pin `foo` that was added manually, but there is also a root package with `foo` in `pin-depends`.

Another example is when someone runs `duniverse pin bar` without realising that there's a `pin-depends` entry for `bar` in one of the opam files.

I see `dune-get` as kind of a "lock" files, so to me, when running `duniverse init`, opam pins should overwrite what's already in `dune-get`.

Thoughts?

@avsm Submitting this as a draft for now to clarify this point first. To be honest I think this is useful even without conflict resolution. We can throw an error if there're conflicts and let users deal with them manually.