### PR TITLE
Fix opam recursion when performing the lock step

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,10 @@
 
 ### Fixed
 
+- Fix `--recurse-opam` option for the monorepo lock phase: correctly perform special directory 
+  filtering, add an error message when two versions of the same package opam file exist in the 
+  source tree, perform package name filtering before checking for uniqueness (#151, @TheLortex)
+
 ### Removed
 
 ### Security

--- a/cli/lock.ml
+++ b/cli/lock.ml
@@ -80,7 +80,7 @@ let local_packages ~recurse ~explicit_list repo =
       Repo.local_packages ~recurse repo >>| fun local_paths ->
       String.Map.map ~f:(fun path -> (None, path)) local_paths
   | _ ->
-      Repo.local_packages ~recurse:true repo >>= fun local_paths ->
+      Repo.local_packages ~recurse:true ~filter:explicit_list repo >>= fun local_paths ->
       filter_local_packages ~explicit_list local_paths
 
 let read_opam fpath =

--- a/lib/repo.ml
+++ b/lib/repo.ml
@@ -10,7 +10,8 @@ let local_packages ~recurse t =
   if not exists then Ok String.Map.empty
   else
     let traverse =
-      if recurse then `Sat (fun p -> Ok (not (List.mem (Fpath.to_string p) ~set:folder_blacklist)))
+      if recurse then
+        `Sat (fun p -> Ok (not (List.mem (Fpath.to_string (Fpath.base p)) ~set:folder_blacklist)))
       else `Sat (fun p -> Ok (Fpath.equal p t))
     in
     Bos.OS.Path.fold

--- a/lib/repo.ml
+++ b/lib/repo.ml
@@ -19,7 +19,13 @@ let local_packages ~recurse t =
       ~traverse
       (fun path acc -> Fpath.(basename (rem_ext path), t // path) :: acc)
       [] [ t ]
-    >>| String.Map.of_list_exn
+    >>= fun lst ->
+    String.Map.of_list lst
+    |> Result.map_error ~f:(fun (_, a, b) ->
+           `Msg
+             (Printf.sprintf
+                "Conflicting definitions for the same package have been found:\n- %s\n- %s"
+                (Fpath.to_string a) (Fpath.to_string b)))
 
 let dune_project t = Fpath.(t / "dune-project")
 

--- a/lib/repo.mli
+++ b/lib/repo.mli
@@ -3,10 +3,15 @@ open Import
 
 type t = Fpath.t
 
-val local_packages : recurse:bool -> t -> (Fpath.t String.Map.t, [> `Msg of string ]) result
+val local_packages :
+  recurse:bool ->
+  ?filter:Types.Opam.package list ->
+  t ->
+  (Fpath.t String.Map.t, [> `Msg of string ]) result
 (** Returns the locally defined opam packages as a map from package names to
     to the corresponding .opam file path.
-    Only considers packages defined at the repo's root unless [recurse] is [true]. *)
+    Only considers packages defined at the repo's root unless [recurse] is [true].
+    Only considers packages listed in [filter] if the parameter is used.  *)
 
 val dune_project : t -> Fpath.t
 (** Returns the path to the dune-project file. *)


### PR DESCRIPTION
My proposal to fix https://github.com/ocamllabs/opam-monorepo/issues/150

Each commit is more or less independent from the other, so we can discuss them separately if needed. 
The first one is a bug fix, as it was already intended to ignore `_build` and `duniverse` folders.
The second one is the addition of an error message.
The third one allows the user to use `opam monorepo lock` even if conflicting package definitions exist, as long as the requested package name is given.