### PR TITLE
Use a more robust way of finding the main branch

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@
 ### Fixed
 
 - Fix a log that was still refering to the old tool name `duniverse` (#158, @rizo)
+- Use `git ls-remote --symref <remote> HEAD` to find the main branch of a given remote. 
+  (#157, fixes #114, @TheLortex)
 
 ### Removed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,8 +9,9 @@
 ### Fixed
 
 - Fix a log that was still refering to the old tool name `duniverse` (#158, @rizo)
-- Use `git ls-remote --symref <remote> HEAD` to find the main branch of a given remote. 
-  (#157, fixes #114, @TheLortex)
+- Improve how the default branch for a git repository is queried, fixing a bug
+  where opam-monorepo wouldn't work outside of of git repo and a bug where it wouldn't
+  work on non-english systems. (#157, fixes #114, @TheLortex)
 
 ### Removed
 

--- a/lib/git.mli
+++ b/lib/git.mli
@@ -11,6 +11,11 @@ module Ls_remote : sig
       and returns the commit pointed by [ref] if it can be determined from it.
       It will work even if the repo uses packed-refs. *)
 
+  val branch_of_symref :
+    symref:string -> string list -> (string, [> `Not_a_symref | `Msg of string ]) result
+  (** [ref_of_symref ~symref ls_remote_output] parses the output from git ls-remote --symref
+      and returns the underlying branch pointed by the symbolic ref [symref]. *)
+
   (**/**)
 
   (* Exposed for test purposes only *)


### PR DESCRIPTION
As suggested by @emillon, we can use `git ls-remote --symref` to find the main branch of a given remote. The output is language-agnostic so that fixes #114. It also allows `opam-monorepo` to work outside of git repositories.

I added tests so hopefully I won't break anything.