### PR TITLE
Pin depends

### DIFF
--- a/cli/lock.ml
+++ b/cli/lock.ml
@@ -111,6 +111,7 @@ let root_pin_depends local_opam_files =
 
 let pull_pin_depends (pin_depends : (OpamPackage.t * OpamUrl.t) list) =
   let hashes = [] in
+  let pins_tmp_dir = Fpath.v "/tmp/opam-monorepo/pins/" in
   OpamGlobalState.with_ `Lock_none (fun global_state ->
       let cache_dir = OpamRepositoryPath.download_cache global_state.OpamStateTypes.root in
       Logs.debug (fun l ->
@@ -118,17 +119,23 @@ let pull_pin_depends (pin_depends : (OpamPackage.t * OpamUrl.t) list) =
             Fmt.(list ~sep:(unit " ") Fmt.(styled `Yellow string))
             (List.map ~f:(fun (pkg, _) -> OpamPackage.to_string pkg) pin_depends));
       let open Result.O in
-      let pull (pkg, url) =
+      let command (pkg, url) =
         let label = OpamPackage.to_string pkg in
-        let out_dir = OpamFilename.Dir.of_string ("/tmp/opam-monorepo/pins/" ^ label) in
+        let out_dir = Fpath.(pins_tmp_dir / label) in
         let open OpamProcess.Job.Op in
-        OpamRepository.pull_tree ~cache_dir label out_dir hashes [ url ] @@| function
-        | Result _ | Up_to_date _ -> Ok ()
+        OpamRepository.pull_tree ~cache_dir label
+          (OpamFilename.Dir.of_string (Fpath.to_string out_dir))
+          hashes [ url ]
+        @@| function
+        | Result _ | Up_to_date _ ->
+            let opam_path = Fpath.(out_dir / OpamPackage.name_to_string pkg |> add_ext "opam") in
+            read_opam opam_path >>= fun opam ->
+            Ok (OpamPackage.name pkg, (OpamPackage.version pkg, opam))
         | Not_available (_, long_msg) ->
             Error (`Msg (Printf.sprintf "Failed to pull %s: %s" label long_msg))
       in
       let jobs = !OpamStateConfig.r.dl_jobs in
-      OpamParallel.map ~jobs ~command:pull pin_depends |> Result.List.all >>= fun _ -> Ok ())
+      Result.List.all (OpamParallel.map ~jobs ~command pin_depends) >>| OpamPackage.Name.Map.of_list)
 
 let run (`Repo repo) (`Recurse_opam recurse) (`Build_only build_only) (`Local_packages lp) () =
   let open Rresult.R.Infix in
@@ -140,8 +147,11 @@ let run (`Repo repo) (`Recurse_opam recurse) (`Build_only build_only) (`Local_pa
   check_root_packages ~local_packages >>= fun () ->
   local_paths_to_opam_map local_paths >>= fun local_opam_files ->
   let root_pin_depends = root_pin_depends local_opam_files in
-  pull_pin_depends root_pin_depends >>= fun () ->
+  pull_pin_depends root_pin_depends >>= fun pin_opam_files ->
   Repo.lockfile ~local_packages repo >>= fun lockfile_path ->
+  let local_opam_files =
+    OpamPackage.Name.Map.union (fun _local pin -> pin) local_opam_files pin_opam_files
+  in
   calculate_opam ~build_only ~local_opam_files ~local_packages >>= fun package_summaries ->
   Common.Logs.app (fun l -> l "Calculating exact pins for each of them.");
   compute_duniverse ~package_summaries >>= resolve_ref >>= fun duniverse ->

--- a/cli/lock.ml
+++ b/cli/lock.ml
@@ -110,32 +110,36 @@ let root_pin_depends local_opam_files =
     local_opam_files []
 
 let pull_pin_depends (pin_depends : (OpamPackage.t * OpamUrl.t) list) =
-  let hashes = [] in
-  let pins_tmp_dir = Fpath.v "/tmp/opam-monorepo/pins/" in
-  OpamGlobalState.with_ `Lock_none (fun global_state ->
-      let cache_dir = OpamRepositoryPath.download_cache global_state.OpamStateTypes.root in
-      Logs.debug (fun l ->
-          l "Pulling pin depends: %a"
-            Fmt.(list ~sep:(unit " ") Fmt.(styled `Yellow string))
-            (List.map ~f:(fun (pkg, _) -> OpamPackage.to_string pkg) pin_depends));
-      let open Result.O in
-      let command (pkg, url) =
-        let label = OpamPackage.to_string pkg in
-        let out_dir = Fpath.(pins_tmp_dir / label) in
-        let open OpamProcess.Job.Op in
-        OpamRepository.pull_tree ~cache_dir label
-          (OpamFilename.Dir.of_string (Fpath.to_string out_dir))
-          hashes [ url ]
-        @@| function
-        | Result _ | Up_to_date _ ->
-            let opam_path = Fpath.(out_dir / OpamPackage.name_to_string pkg |> add_ext "opam") in
-            read_opam opam_path >>= fun opam ->
-            Ok (OpamPackage.name pkg, (OpamPackage.version pkg, opam))
-        | Not_available (_, long_msg) ->
-            Error (`Msg (Printf.sprintf "Failed to pull %s: %s" label long_msg))
-      in
-      let jobs = !OpamStateConfig.r.dl_jobs in
-      Result.List.all (OpamParallel.map ~jobs ~command pin_depends) >>| OpamPackage.Name.Map.of_list)
+  (* TODO: Group pin-depends with the same url. *)
+  if List.is_empty pin_depends then Ok OpamPackage.Name.Map.empty
+  else
+    let pins_tmp_dir = Fpath.v "/tmp/opam-monorepo/pins/" in
+    OpamGlobalState.with_ `Lock_none (fun global_state ->
+        let cache_dir = OpamRepositoryPath.download_cache global_state.OpamStateTypes.root in
+        Logs.debug (fun l ->
+            l "Pulling pin depends: %a"
+              Fmt.(list ~sep:(unit " ") Fmt.(styled `Yellow string))
+              (List.map ~f:(fun (pkg, _) -> OpamPackage.to_string pkg) pin_depends));
+        let open Result.O in
+        let command (pkg, url) =
+          let label = OpamPackage.to_string pkg in
+          let out_dir = Fpath.(pins_tmp_dir / label) in
+          let open OpamProcess.Job.Op in
+          OpamRepository.pull_tree ~cache_dir label
+            (OpamFilename.Dir.of_string (Fpath.to_string out_dir))
+            [] [ url ]
+          @@| function
+          | Result _ | Up_to_date _ ->
+              let opam_path = Fpath.(out_dir / OpamPackage.name_to_string pkg |> add_ext "opam") in
+              read_opam opam_path >>= fun opam ->
+              let opam = OpamFile.OPAM.with_url (OpamFile.URL.create url) opam in
+              Ok (OpamPackage.name pkg, (OpamPackage.version pkg, opam))
+          | Not_available (_, long_msg) ->
+              Error (`Msg (Printf.sprintf "Failed to pull %s: %s" label long_msg))
+        in
+        let jobs = !OpamStateConfig.r.dl_jobs in
+        OpamParallel.map ~jobs ~command pin_depends
+        |> Result.List.all >>| OpamPackage.Name.Map.of_list)
 
 let run (`Repo repo) (`Recurse_opam recurse) (`Build_only build_only) (`Local_packages lp) () =
   let open Rresult.R.Infix in
@@ -148,11 +152,13 @@ let run (`Repo repo) (`Recurse_opam recurse) (`Build_only build_only) (`Local_pa
   local_paths_to_opam_map local_paths >>= fun local_opam_files ->
   let root_pin_depends = root_pin_depends local_opam_files in
   pull_pin_depends root_pin_depends >>= fun pin_opam_files ->
-  Repo.lockfile ~local_packages repo >>= fun lockfile_path ->
+  let pin_packages = OpamPackage.Name.Map.keys pin_opam_files in
   let local_opam_files =
     OpamPackage.Name.Map.union (fun _local pin -> pin) local_opam_files pin_opam_files
   in
-  calculate_opam ~build_only ~local_opam_files ~local_packages >>= fun package_summaries ->
+  Repo.lockfile ~local_packages repo >>= fun lockfile_path ->
+  calculate_opam ~build_only ~local_opam_files ~local_packages ~pin_packages
+  >>= fun package_summaries ->
   Common.Logs.app (fun l -> l "Calculating exact pins for each of them.");
   compute_duniverse ~package_summaries >>= resolve_ref >>= fun duniverse ->
   let root_packages = String.Map.keys local_paths in

--- a/lib/opam_solve.ml
+++ b/lib/opam_solve.ml
@@ -58,9 +58,11 @@ end
 
 module Local_solver = Opam_0install.Solver.Make (Switch_and_local_packages_context)
 
-let calculate_raw ~build_only ~local_packages switch_state =
+let calculate_raw ~build_only ~local_packages ~pin_packages switch_state =
   let local_packages_names = OpamPackage.Name.Map.keys local_packages in
-  let names_set = OpamPackage.Name.Set.of_list local_packages_names in
+  let names_set =
+    OpamPackage.Name.Set.(diff (of_list local_packages_names) (of_list pin_packages))
+  in
   let test = if build_only then OpamPackage.Name.Set.empty else names_set in
   let context =
     Switch_and_local_packages_context.create ~test ~constraints:OpamPackage.Name.Map.empty
@@ -80,15 +82,20 @@ let calculate_raw ~build_only ~local_packages switch_state =
       in
       Ok deps
 
-let get_opam_info ~switch_state pkg =
-  let opam_file = OpamSwitchState.opam switch_state pkg in
+let get_opam_info ~local_opam_files ~switch_state pkg =
+  let opam_file =
+    if OpamPackage.Name.Map.mem pkg.OpamPackage.name local_opam_files then
+      snd (OpamPackage.Name.Map.find pkg.OpamPackage.name local_opam_files)
+    else OpamSwitchState.opam switch_state pkg
+  in
   Opam.Package_summary.from_opam ~pkg opam_file
 
 (* TODO catch exceptions and turn to error *)
 
-let calculate ~build_only ~local_opam_files ~local_packages switch_state =
+let calculate ~build_only ~local_opam_files ~local_packages ~pin_packages switch_state =
   let open Rresult.R.Infix in
-  calculate_raw ~build_only ~local_packages:local_opam_files switch_state >>= fun deps ->
+  calculate_raw ~build_only ~local_packages:local_opam_files ~pin_packages switch_state
+  >>= fun deps ->
   Logs.app (fun l ->
       l "%aFound %a opam dependencies for %a." Pp.Styled.header ()
         Fmt.(styled `Green int)
@@ -103,4 +110,4 @@ let calculate ~build_only ~local_opam_files ~local_packages switch_state =
         deps);
   Logs.app (fun l ->
       l "%aQuerying opam database for their metadata and Dune compatibility." Pp.Styled.header ());
-  Ok (List.map ~f:(get_opam_info ~switch_state) deps)
+  Ok (List.map ~f:(get_opam_info ~local_opam_files ~switch_state) deps)

--- a/lib/opam_solve.mli
+++ b/lib/opam_solve.mli
@@ -2,6 +2,7 @@ val calculate :
   build_only:bool ->
   local_opam_files:(OpamTypes.version * OpamFile.OPAM.t) OpamPackage.Name.Map.t ->
   local_packages:Types.Opam.package list ->
+  pin_packages:OpamPackage.Name.t list ->
   OpamStateTypes.unlocked OpamStateTypes.switch_state ->
   (Opam.Package_summary.t list, [> `Msg of string ]) result
 (** Calculates a solution for the provided local packages and their opam files


### PR DESCRIPTION
This is a fairly ad-hoc implementation of pin-depends (#153).

The process is as follows:

1. `pin-depends` entries are read from all local opam files.
2. Referenced sources are fetched with opam into `/tmp/opam-monorepo/pins/`.
3. The opam files from pins are collected with their `url_src` set to the pinned url (this is similar to what opam does on `opam pin` and is important otherwise the packages will be filtered out from duniverse).
4. The opam files from pins are added to `local_opam_files` to participate in dependency resolution.
5. Opam solve gets a list of pin packages to ensure they are not filtered out from the solution.
6. Finally, when looking up opam files to create summaries, the local opam files are used (for pins only, as the local packages are excluded anyway).

I want to spend a few days testing this and might refactor the code to split up `pull_pin_depends` into smaller functions and add some tests.

@NathanReb let me know what you think about this approach. Happy to make any changes you think are necessary.