### PR TITLE
Add `--keep-clone` flag to the `pull` command.

### DIFF
--- a/cli/common.ml
+++ b/cli/common.ml
@@ -22,6 +22,10 @@ module Arg = struct
 
   let non_empty_list_opt = Cmdliner.Term.pure (function [] -> None | l -> Some l)
 
+  let keep_clone =
+    let doc = "Keep the `.git' directory after pulling the vendored soruces." in
+    named (fun x -> `Keep_clone x) Cmdliner.Arg.(value & flag & info [ "keep-clone" ] ~doc)
+
   let duniverse_repos =
     let open Cmdliner in
     let docv = "REPOSITORIES" in

--- a/cli/common.mli
+++ b/cli/common.mli
@@ -24,6 +24,9 @@ module Arg : sig
   (** CLI flag to skip any prompt and perform actions straight away. The value of this flag
       must be passed to [Prompt.confirm]. *)
 
+  val keep_clone : [ `Keep_clone of bool ] Cmdliner.Term.t
+  (** CLI flag to keep the [.git] directory after pulling the vendored sources. *)
+
   val duniverse_repos : [ `Duniverse_repos of string list option ] Cmdliner.Term.t
   (** CLI arguments consisting of the list of source deps repo to process. If [None],
       the whole duniverse should be processed. If [Some l] then [l] is non empty. *)

--- a/cli/pull.ml
+++ b/cli/pull.ml
@@ -53,7 +53,7 @@ let check_dune_lang_version ~yes ~repo =
     Logs.debug (fun l -> l "No dune-project found");
     Ok () )
 
-let run (`Yes yes) (`Repo repo) (`Duniverse_repos duniverse_repos) () =
+let run (`Yes yes) (`Repo repo) (`Keep_clone keep_clone) (`Duniverse_repos duniverse_repos) () =
   let open Result.O in
   Repo.lockfile repo >>= fun lockfile_path ->
   Lockfile.load ~file:lockfile_path >>= fun lockfile ->
@@ -66,7 +66,7 @@ let run (`Yes yes) (`Repo repo) (`Duniverse_repos duniverse_repos) () =
       Common.filter_duniverse ~to_consider:duniverse_repos duniverse >>= fun duniverse ->
       check_dune_lang_version ~yes ~repo >>= fun () ->
       OpamGlobalState.with_ `Lock_none (fun global_state ->
-          Pull.duniverse ~global_state ~repo ~full duniverse)
+          Pull.duniverse ~global_state ~repo ~full ~trim_clone:(not keep_clone) duniverse)
 
 let info =
   let open Cmdliner in
@@ -89,7 +89,7 @@ let info =
 let term =
   Cmdliner.Term.(
     term_result
-      ( const run $ Common.Arg.yes $ Common.Arg.repo $ Common.Arg.duniverse_repos
-      $ Common.Arg.setup_logs () ))
+      ( const run $ Common.Arg.yes $ Common.Arg.repo $ Common.Arg.keep_clone
+      $ Common.Arg.duniverse_repos $ Common.Arg.setup_logs () ))
 
 let cmd = (term, info)

--- a/cli/pull.mli
+++ b/cli/pull.mli
@@ -3,6 +3,7 @@ val cmd : unit Cmdliner.Term.t * Cmdliner.Term.info
 val run :
   [< `Yes of bool ] ->
   [< `Repo of Fpath.t ] ->
+  [< `Keep_clone of bool ] ->
   [< `Duniverse_repos of string list option ] ->
   unit ->
   (unit, Rresult.R.msg) result

--- a/lib/pull.ml
+++ b/lib/pull.ml
@@ -41,7 +41,7 @@ let pre_pull_clean_up ~full ~duniverse_dir duniverse =
     Result.List.iter duniverse ~f:(fun { Duniverse.Repo.dir; _ } ->
         Bos.OS.Dir.delete ~must_exist:false ~recurse:true Fpath.(duniverse_dir / dir))
 
-let duniverse ~full ~repo ~global_state duniverse =
+let duniverse ~full ~repo ~global_state ~trim_clone duniverse =
   if List.is_empty duniverse then Ok ()
   else
     let open Result.O in
@@ -49,4 +49,4 @@ let duniverse ~full ~repo ~global_state duniverse =
     pre_pull_clean_up ~full ~duniverse_dir duniverse >>= fun () ->
     Bos.OS.Dir.create duniverse_dir >>= fun _created ->
     mark_duniverse_content_as_vendored ~duniverse_dir >>= fun () ->
-    pull_source_dependencies ~global_state ~trim_clone:true ~duniverse_dir duniverse
+    pull_source_dependencies ~global_state ~trim_clone ~duniverse_dir duniverse

--- a/lib/pull.mli
+++ b/lib/pull.mli
@@ -2,6 +2,7 @@ val duniverse :
   full:bool ->
   repo:Fpath.t ->
   global_state:OpamStateTypes.unlocked OpamStateTypes.global_state ->
+  trim_clone:bool ->
   Duniverse.t ->
   (unit, [> Rresult.R.msg ]) result
 (** [duniverse ~full ~repo ~global_state duniverse]


### PR DESCRIPTION
Allows to keep the pulled sources as git repositories. This in combination with having `duniverse` in `.gitignore` results in a nice workflow for contributing changes to vendored packages.

I named the option `--keep-clone` instead of `--trim-clone=false` to keep it as a flag. I can can the name if it's not very clear.