### PR TITLE
Fix lockfile path inference

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@
   provided, use the value of the version field in the opam files instead of the
   default `zdev` if it is defined (#183, @emillon)
 
+- Add a `-l`/`--lockfile` command line option to explicitly set the lockfile
+  to use or generate in `pull` or `lock` (#163, @NathanReb)
+
 ### Changed
 
 ### Deprecated
@@ -21,6 +24,11 @@
 - Simply warn instead of exiting when the dune-project file can't be parsed
   by `pull` as it only use it to suggest updating the lang version for
   convenience (#191, @NathanReb)
+
+- Fix a bug where `pull` and `lock` would expect the lockfile to sit in a
+  different place and pull would fail. `pull` now simply looks for a
+  `.opam.locked` file and pulls it unless there are multiple matching files in
+  the repository's root. (#163, @NathanReb)
 
 ### Removed
 

--- a/cli/common.ml
+++ b/cli/common.ml
@@ -14,6 +14,16 @@ module Arg = struct
         & opt fpath (Fpath.v (Sys.getcwd ()))
         & info [ "r"; "repo" ] ~docv:"TARGET_REPO" ~doc)
 
+  let lockfile =
+    let doc =
+      "Path to the lockfile to use or generate. Defaults \
+       $(b,<project-name>.opam.locked)"
+    in
+    named
+      (fun x -> `Lockfile x)
+      Cmdliner.Arg.(
+        value & opt (some fpath) None & info [ "l"; "lockfile" ] ~doc)
+
   let yes =
     let doc = "Do not prompt for confirmation and always assume yes" in
     named

--- a/cli/common.mli
+++ b/cli/common.mli
@@ -18,6 +18,9 @@ module Arg : sig
   (** CLI option to specify the root directory of the project. Used to find root packages,
       duniverse files and directories. Defaults to the current directory. *)
 
+  val lockfile : [ `Lockfile of Fpath.t option ] Cmdliner.Term.t
+  (** CLI option to specify the path to the lockfile to use or generate. *)
+
   val yes : [ `Yes of bool ] Cmdliner.Term.t
   (** CLI flag to skip any prompt and perform actions straight away. The value of this flag
       must be passed to [Prompt.confirm]. *)

--- a/cli/lock.ml
+++ b/cli/lock.ml
@@ -167,9 +167,17 @@ let root_depexts local_opam_files =
       OpamFile.OPAM.depexts opam_file :: acc)
     local_opam_files []
 
+let lockfile_path ~explicit_lockfile ~local_packages repo =
+  match explicit_lockfile with
+  | Some path -> Ok path
+  | None ->
+      Repo.lockfile
+        ~local_packages:(List.map ~f:Package_argument.name local_packages)
+        repo
+
 let run (`Repo repo) (`Recurse_opam recurse) (`Build_only build_only)
     (`Allow_jbuilder allow_jbuilder) (`Ocaml_version ocaml_version)
-    (`Local_packages lp) () =
+    (`Local_packages lp) (`Lockfile explicit_lockfile) () =
   let open Rresult.R.Infix in
   local_packages ~recurse ~explicit_list:lp repo >>= fun local_paths ->
   let local_packages =
@@ -179,10 +187,7 @@ let run (`Repo repo) (`Recurse_opam recurse) (`Build_only build_only)
   in
   check_root_packages ~local_packages >>= fun () ->
   local_paths_to_opam_map local_paths >>= fun local_opam_files ->
-  Repo.lockfile
-    ~local_packages:(List.map ~f:Package_argument.name local_packages)
-    repo
-  >>= fun lockfile_path ->
+  lockfile_path ~explicit_lockfile ~local_packages repo >>= fun lockfile_path ->
   calculate_opam ~build_only ~allow_jbuilder ~ocaml_version ~local_opam_files
   >>= fun package_summaries ->
   Common.Logs.app (fun l -> l "Calculating exact pins for each of them.");
@@ -288,6 +293,6 @@ let term =
   let open Term in
   term_result
     (const run $ Common.Arg.repo $ recurse_opam $ build_only $ allow_jbuilder
-   $ ocaml_version $ packages $ Common.Arg.setup_logs ())
+   $ ocaml_version $ packages $ Common.Arg.lockfile $ Common.Arg.setup_logs ())
 
 let cmd = (term, info)

--- a/cli/pull.mli
+++ b/cli/pull.mli
@@ -1,8 +1,1 @@
 val cmd : unit Cmdliner.Term.t * Cmdliner.Term.info
-
-val run :
-  [< `Yes of bool ] ->
-  [< `Repo of Fpath.t ] ->
-  [< `Duniverse_repos of string list option ] ->
-  unit ->
-  (unit, Rresult.R.msg) result

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -47,3 +47,5 @@ let ocaml_src_dir = Fpath.(bootstrap_src_dir / "ocaml")
 let dune_src_dir = Fpath.(bootstrap_src_dir / "dune")
 
 let dune_latest_tag = "2.6.0" (* TODO get from opam metadata *)
+
+let lockfile_ext = ".opam.locked"

--- a/lib/repo.ml
+++ b/lib/repo.ml
@@ -4,6 +4,9 @@ type t = Fpath.t
 
 let folder_blacklist = [ "_build"; "_opam"; Fpath.to_string Config.vendor_dir ]
 
+(* We accept a filter here instead of filtering the result because
+   some repos have duplicate dummy opam files that would fail the uniqueness
+   check. Dune is a good example, the blackbox tests contain duplicate opam files *)
 let local_packages ~recurse ?filter t =
   let open Result.O in
   Bos.OS.Dir.exists t >>= fun exists ->
@@ -51,7 +54,7 @@ let project_name t =
   let dune_project = dune_project t in
   Dune_file.Raw.as_sexps dune_project >>= Dune_file.Project.name
 
-let lockfile ~name t = Fpath.(t / (name ^ ".opam.locked"))
+let lockfile ~name t = Fpath.(t / (name ^ Config.lockfile_ext))
 
 let lockfile ?local_packages:lp t =
   let open Result.O in

--- a/lib/repo.mli
+++ b/lib/repo.mli
@@ -28,4 +28,5 @@ val lockfile :
     file at the root of the repo.
     If it contains multiple packages, then it's the ["<project_name>.opam.locked"] file
     at the root of the repo.
-    One can provide [local_packages] if they were already computed. *)
+    One can provide [local_packages] if they were already computed are if only a subset
+    of the local packages must be taken into account. *)


### PR DESCRIPTION
Fixes #162 

The lockfile path inference mechanism was broken because it depended on which packages were locked on one hand (when running `lock`) and only on which packages were defined at the root of the project on the other (when running `pull`).

It is now symetrical and only relies on the project name as defined in the `dune-project` file so `lock` and `pull` will get to the same conclusion regarding its location. This can be considered a breaking change as single package repositories could get away without defining a name in the dune-project before and can't do that anymore. I think it is fine to ask of our users that they fill in this field.

I also added a CLI option to explicitly set the path to the lockfile, providing a bit of flexibility for specific use cases.