### PR TITLE
Exclude packages depending on jbuilder by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@
 
 ### Changed
 
+- Exclude packages depending on `jbuilder` from the lock step. Since dune 2.0, `jbuild` files are
+  not supported. A new `--allow-jbuilder` option have been added to enable the old behavior. 
+
 ### Deprecated
 
 ### Fixed

--- a/lib/opam.ml
+++ b/lib/opam.ml
@@ -1,11 +1,11 @@
 open Import
 
-let depends_on_dune (formula : OpamTypes.filtered_formula) =
+let depends_on_dune ~allow_jbuilder (formula : OpamTypes.filtered_formula) =
   let dune = OpamPackage.Name.of_string "dune" in
   let jbuilder = OpamPackage.Name.of_string "jbuilder" in
   let is_duneish name =
     let eq n n' = OpamPackage.Name.compare n n' = 0 in
-    eq dune name || eq jbuilder name
+    eq dune name || (allow_jbuilder && eq jbuilder name)
   in
   OpamFormula.fold_left (fun acc (name, _) -> acc || is_duneish name) false formula
 

--- a/lib/opam.mli
+++ b/lib/opam.mli
@@ -44,7 +44,7 @@ module Pp : sig
   val hash : OpamHash.t Fmt.t
 end
 
-val depends_on_dune : OpamTypes.filtered_formula -> bool
+val depends_on_dune : allow_jbuilder:bool -> OpamTypes.filtered_formula -> bool
 (** Returns whether the given depends field formula contains a dependency to dune or jbuilder *)
 
 val pull_tree :

--- a/lib/opam_solve.ml
+++ b/lib/opam_solve.ml
@@ -5,6 +5,7 @@ module Switch_and_local_packages_context : sig
 
   val create :
     ?test:OpamPackage.Name.Set.t ->
+    allow_jbuilder:bool ->
     local_packages:(OpamPackage.Version.t * OpamFile.OPAM.t) OpamPackage.Name.Map.t ->
     constraints:OpamFormula.version_constraint OpamTypes.name_map ->
     OpamStateTypes.unlocked OpamStateTypes.switch_state ->
@@ -13,6 +14,7 @@ end = struct
   type t = {
     switch_context : Opam_0install.Switch_context.t;
     local_packages : (OpamPackage.Version.t * OpamFile.OPAM.t) OpamPackage.Name.Map.t;
+    allow_jbuilder : bool;
   }
 
   type rejection = Non_dune | Switch_rejection of Opam_0install.Switch_context.rejection
@@ -21,33 +23,36 @@ end = struct
     | Non_dune -> Fmt.pf fmt "Doesn't build with dune"
     | Switch_rejection r -> Opam_0install.Switch_context.pp_rejection fmt r
 
-  let create ?test ~local_packages ~constraints switch_state =
+  let create ?test ~allow_jbuilder ~local_packages ~constraints switch_state =
     let switch_context = Opam_0install.Switch_context.create ?test ~constraints switch_state in
-    { switch_context; local_packages }
+    { switch_context; local_packages; allow_jbuilder }
 
-  let is_valid_candidate ~name ~version opam_file =
+  let is_valid_candidate ~allow_jbuilder ~name ~version opam_file =
     let pkg = OpamPackage.create name version in
     let depends = OpamFile.OPAM.depends opam_file in
-    let uses_dune = Opam.depends_on_dune depends in
+    let uses_dune = Opam.depends_on_dune ~allow_jbuilder depends in
     let summary = Opam.Package_summary.from_opam ~pkg opam_file in
     Opam.Package_summary.is_base_package summary
     || Opam.Package_summary.is_virtual summary
     || uses_dune
 
-  let filter_candidates ~name versions =
+  let filter_candidates ~allow_jbuilder ~name versions =
     List.map
       ~f:(fun (version, result) ->
         match result with
         | Error r -> (version, Error (Switch_rejection r))
         | Ok opam_file ->
-            if is_valid_candidate ~name ~version opam_file then (version, Ok opam_file)
+            if is_valid_candidate ~allow_jbuilder ~name ~version opam_file then
+              (version, Ok opam_file)
             else (version, Error Non_dune))
       versions
 
-  let candidates { switch_context; local_packages } name =
+  let candidates { switch_context; local_packages; allow_jbuilder } name =
     match OpamPackage.Name.Map.find_opt name local_packages with
     | Some (version, opam_file) -> [ (version, Ok opam_file) ]
-    | None -> Opam_0install.Switch_context.candidates switch_context name |> filter_candidates ~name
+    | None ->
+        Opam_0install.Switch_context.candidates switch_context name
+        |> filter_candidates ~allow_jbuilder ~name
 
   let user_restrictions { switch_context; _ } name =
     Opam_0install.Switch_context.user_restrictions switch_context name
@@ -58,13 +63,13 @@ end
 
 module Local_solver = Opam_0install.Solver.Make (Switch_and_local_packages_context)
 
-let calculate_raw ~build_only ~local_packages switch_state =
+let calculate_raw ~build_only ~allow_jbuilder ~local_packages switch_state =
   let local_packages_names = OpamPackage.Name.Map.keys local_packages in
   let names_set = OpamPackage.Name.Set.of_list local_packages_names in
   let test = if build_only then OpamPackage.Name.Set.empty else names_set in
   let context =
-    Switch_and_local_packages_context.create ~test ~constraints:OpamPackage.Name.Map.empty
-      ~local_packages switch_state
+    Switch_and_local_packages_context.create ~test ~allow_jbuilder
+      ~constraints:OpamPackage.Name.Map.empty ~local_packages switch_state
   in
   let result = Local_solver.solve context local_packages_names in
   match result with
@@ -86,9 +91,10 @@ let get_opam_info ~switch_state pkg =
 
 (* TODO catch exceptions and turn to error *)
 
-let calculate ~build_only ~local_opam_files ~local_packages switch_state =
+let calculate ~build_only ~allow_jbuilder ~local_opam_files ~local_packages switch_state =
   let open Rresult.R.Infix in
-  calculate_raw ~build_only ~local_packages:local_opam_files switch_state >>= fun deps ->
+  calculate_raw ~build_only ~allow_jbuilder ~local_packages:local_opam_files switch_state
+  >>= fun deps ->
   Logs.app (fun l ->
       l "%aFound %a opam dependencies for %a." Pp.Styled.header ()
         Fmt.(styled `Green int)

--- a/lib/opam_solve.mli
+++ b/lib/opam_solve.mli
@@ -1,5 +1,6 @@
 val calculate :
   build_only:bool ->
+  allow_jbuilder:bool ->
   local_opam_files:(OpamTypes.version * OpamFile.OPAM.t) OpamPackage.Name.Map.t ->
   local_packages:Types.Opam.package list ->
   OpamStateTypes.unlocked OpamStateTypes.switch_state ->


### PR DESCRIPTION
Since dune 2.0, `jbuild` files are not supported. As a consequence, if `opam monorepo` was to vendor a project depending on `jbuilder`, it would break the whole monorepo build.   

There are two changes in this PR:
- by default: don't include packages depending on `jbuilder` for the lockfile resolution.
- add a `--allow-jbuilder` option to enable the old behavior.  

