### PR TITLE
Fix git default branch computation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@
 
 ### Fixed
 
+- Fix the default branch mechanism when the opam remote starts with `git+https` (#166, @TheLortex)
 - Fix a log that was still refering to the old tool name `duniverse` (#158, @rizo)
 - Improve how the default branch for a git repository is queried, fixing a bug
   where opam-monorepo wouldn't work outside of of git repo and a bug where it wouldn't

--- a/cli/lock.ml
+++ b/cli/lock.ml
@@ -16,15 +16,15 @@ let check_root_packages ~local_packages =
             local_packages Pp.plural local_packages);
       Ok ()
 
+let opam_to_git_remote remote =
+  match String.lsplit2 ~on:'+' remote with Some ("git", remote) -> remote | _ -> remote
+
 let compute_duniverse ~package_summaries =
-  let get_default_branch remote = Exec.git_default_branch ~remote () in
+  let get_default_branch remote = Exec.git_default_branch ~remote:(opam_to_git_remote remote) () in
   Duniverse.from_package_summaries ~get_default_branch package_summaries
 
 let resolve_ref deps =
-  let resolve_ref ~repo ~ref =
-    let repo = match String.lsplit2 ~on:'+' repo with Some ("git", repo) -> repo | _ -> repo in
-    Exec.git_resolve ~remote:repo ~ref
-  in
+  let resolve_ref ~repo ~ref = Exec.git_resolve ~remote:(opam_to_git_remote repo) ~ref in
   Duniverse.resolve ~resolve_ref deps
 
 let current_repos ~repo_state ~switch_state =


### PR DESCRIPTION
When given an opam git remote in the form `git+https://github.com/...`, `git ls-remote --symref <remote> HEAD` would fail as it doesn't recognize urls in the form `git+https`, because this is something specific to opam. 

This PR applies the same mechanism as in `resolve_ref`, which is to remove the `git+` prefix in that situation. 