### PR TITLE
Quieter lock logs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@
 - Recognize packages with an optional dependency on dune as building with dune. This allows
   opam-monorepo to rightfully recognize `opam-file-format` latest versions as building with 
   dune. (#176, @NathanReb)
+- Only print the full list of selected root packages once and only in verbose mode, simply printing
+  the number in the default logs. (#173, @NathanReb)
 
 ### Deprecated
 

--- a/cli/lock.ml
+++ b/cli/lock.ml
@@ -2,18 +2,22 @@ open Import
 open Types
 
 let check_root_packages ~local_packages =
-  match local_packages with
-  | [] ->
+  let count = List.length local_packages in
+  match count with
+  | 0 ->
       Rresult.R.error_msg
         "Cannot find any packages to vendor.\n\
          Either create some *.opam files in the local repository, or specify them manually via \
          'opam monorepo lock <packages>'."
-  | local_packages ->
+  | _ ->
       let pp_package_name fmt { Opam.name; _ } = Fmt.string fmt name in
       Common.Logs.app (fun l ->
-          l "Using locally scanned package%a '%a' as the root%a." Pp.plural local_packages
+          l "Using %d locally scanned package%a as the root%a." count Pp.plural local_packages
+            Pp.plural local_packages);
+      Logs.info (fun l ->
+          l "Root package%a: %a." Pp.plural local_packages
             Fmt.(list ~sep:(unit ",@ ") (styled `Yellow pp_package_name))
-            local_packages Pp.plural local_packages);
+            local_packages);
       Ok ()
 
 let opam_to_git_remote remote =

--- a/lib/opam_solve.ml
+++ b/lib/opam_solve.ml
@@ -110,17 +110,11 @@ let calculate ~build_only ~allow_jbuilder ~local_opam_files ~local_packages ?oca
     switch_state
   >>= fun deps ->
   Logs.app (fun l ->
-      l "%aFound %a opam dependencies for %a." Pp.Styled.header ()
+      l "%aFound %a opam dependencies for the root package%a." Pp.Styled.header ()
         Fmt.(styled `Green int)
-        (List.length deps)
-        Fmt.(list ~sep:(unit " ") Pp.Styled.package)
-        local_packages);
+        (List.length deps) Pp.plural local_packages);
   Logs.info (fun l ->
-      l "The dependencies for %a are: %a"
-        Fmt.(list ~sep:(unit ",@ ") Types.Opam.pp_package)
-        local_packages
-        Fmt.(list ~sep:(unit ",@ ") Opam.Pp.package)
-        deps);
+      l "The dependencies are: %a" Fmt.(list ~sep:(unit ",@ ") Opam.Pp.package) deps);
   Logs.app (fun l ->
       l "%aQuerying opam database for their metadata and Dune compatibility." Pp.Styled.header ());
   Ok (List.map ~f:(get_opam_info ~switch_state) deps)


### PR DESCRIPTION
Fixes #171 

The full list is now only printed when the verbosity level is strictly higher than 0 (the default). The number of root packages is printed instead.

This also removes a couple places where the full list was printed again.