### PR TITLE
Improve detection of packages building with dune

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,9 @@
 
 - Exclude packages depending on `jbuilder` from the lock step. Since dune 2.0, `jbuild` files are
   not supported. A new `--allow-jbuilder` option have been added to enable the old behavior. 
+- Recognize packages with an optional dependency on dune as building with dune. This allows
+  opam-monorepo to rightfully recognize `opam-file-format` latest versions as building with 
+  dune. (#176, @NathanReb)
 
 ### Deprecated
 

--- a/lib/opam_solve.ml
+++ b/lib/opam_solve.ml
@@ -30,7 +30,10 @@ end = struct
   let is_valid_candidate ~allow_jbuilder ~name ~version opam_file =
     let pkg = OpamPackage.create name version in
     let depends = OpamFile.OPAM.depends opam_file in
-    let uses_dune = Opam.depends_on_dune ~allow_jbuilder depends in
+    let depopts = OpamFile.OPAM.depopts opam_file in
+    let uses_dune =
+      Opam.depends_on_dune ~allow_jbuilder depends || Opam.depends_on_dune ~allow_jbuilder depopts
+    in
     let summary = Opam.Package_summary.from_opam ~pkg opam_file in
     Opam.Package_summary.is_base_package summary
     || Opam.Package_summary.is_virtual summary


### PR DESCRIPTION
Some packages such as `opam-file-format` are compatible with dune but don't use it as their primary build mechanism. They mark dune as an optional dependency which made opam-monorepo think they weren't building with dune when they actually could be built with it and therefore could be vendored in a duniverse.

This PR fixes that.