### PR TITLE
Update Github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,6 @@ jobs:
           - 4.08.x
           - 4.09.x
           - 4.10.x
-          - 4.11.x
         os:
           - macos-latest
           - ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Duniverse
+name: opam-monorepo
 on: [push]
 jobs:
   tests:
@@ -6,19 +6,33 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        ocaml-version: [ '4.08.1', '4.09.0' ]
-        operating-system: [macos-latest, ubuntu-latest, windows-latest]
+        ocaml-compiler:
+          - 4.08.x
+          - 4.09.x
+          - 4.10.x
+          - 4.11.x
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
     steps:
-    - uses: actions/checkout@master
-    - uses: avsm/setup-ocaml@master
-      with:
-        ocaml-version: ${{ matrix.ocaml-version }}
-    - name: Dune
-      run: opam install -y dune
-    - name: Build
-      run: opam exec -- dune build
-    - name: Test
-      run: opam exec -- dune runtest
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup OCaml
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+
+      - name: Install Dune
+        run: opam install -y dune
+
+      - name: Build
+        run: opam exec -- dune build
+
+      - name: Test
+        run: opam exec -- dune runtest
+
   binaries:
     name: Binaries
     runs-on: ${{ matrix.operating-system }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,10 @@
 name: opam-monorepo
-on: [push]
+on:
+  pull_request:
+  push:
 jobs:
   tests:
     name: Tests
-    runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
         ocaml-compiler:
@@ -15,6 +16,7 @@ jobs:
           - macos-latest
           - ubuntu-latest
           - windows-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,6 @@
 name: opam-monorepo
 on:
   pull_request:
-  push:
 jobs:
   tests:
     name: Tests
@@ -13,7 +12,6 @@ jobs:
           - 4.10.x
         os:
           - macos-latest
-          - ubuntu-latest
           - windows-latest
     runs-on: ${{ matrix.os }}
     steps:
@@ -33,39 +31,3 @@ jobs:
 
       - name: Test
         run: opam exec -- dune runtest
-
-  binaries:
-    name: Binaries
-    runs-on: ${{ matrix.operating-system }}
-    strategy:
-      matrix:
-        operating-system: [macos-latest, ubuntu-latest, windows-latest]
-        include:
-          - operating-system: ubuntu-latest
-            ocaml-version: 4.10.0+musl+static+flambda
-            artifact-name: duniverse-linux-x86_64
-          - operating-system: macos-latest
-            ocaml-version: 4.10.0
-            artifact-name: duniverse-macos-x86_64
-          - operating-system: windows-latest
-            ocaml-version: 4.10.0
-            artifact-name: duniverse-win32-x86_64
-    steps:
-    - uses: actions/checkout@master
-    - name: Patches (Ubuntu)
-      if: matrix.operating-system == 'ubuntu-latest'
-      run: |
-        sudo add-apt-repository -y ppa:avsm/musl
-        sudo apt-get update
-        sudo apt-get install -y musl-tools
-    - uses: avsm/setup-ocaml@master
-      with:
-        ocaml-version: ${{ matrix.ocaml-version }}
-    - name: Dune
-      run: opam install -y dune
-    - name: Build
-      run: opam exec -- dune build @install
-    - uses: actions/upload-artifact@v1
-      with:
-        name: ${{ matrix.artifact-name }}
-        path: _build/default/bin/opam_monorepo.exe


### PR DESCRIPTION
The github actions were slightly broken. This is an attempt to fix them until we can fully rely on `ocaml-ci`.

@avsm unless you're okay with deleting the Binaries actions, could you look into why they are broken?