### PR TITLE
Discard ocaml variants by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@
   dune. (#176, @NathanReb)
 - Only print the full list of selected root packages once and only in verbose mode, simply printing
   the number in the default logs. (#173, @NathanReb)
+- Improve the solving process so it only accepts base-compilers unless one explicitly requires
+  an compiler variant, either directly or using `ocaml-option-*` packages. (#178, @NathanReb)
 
 ### Deprecated
 

--- a/lib/opam.ml
+++ b/lib/opam.ml
@@ -1,13 +1,17 @@
 open Import
 
-let depends_on_dune ~allow_jbuilder (formula : OpamTypes.filtered_formula) =
-  let dune = OpamPackage.Name.of_string "dune" in
-  let jbuilder = OpamPackage.Name.of_string "jbuilder" in
-  let is_duneish name =
-    let eq n n' = OpamPackage.Name.compare n n' = 0 in
-    eq dune name || (allow_jbuilder && eq jbuilder name)
+let depends_on_any packages (formula : OpamTypes.filtered_formula) =
+  let packages = List.map ~f:OpamPackage.Name.of_string packages in
+  let is_one_of_packages name =
+    List.exists packages ~f:(fun p -> OpamPackage.Name.compare p name = 0)
   in
-  OpamFormula.fold_left (fun acc (name, _) -> acc || is_duneish name) false formula
+  OpamFormula.fold_left (fun acc (name, _) -> acc || is_one_of_packages name) false formula
+
+let depends_on_compiler_variants formula = depends_on_any [ "ocaml-variants" ] formula
+
+let depends_on_dune ~allow_jbuilder (formula : OpamTypes.filtered_formula) =
+  let packages = if allow_jbuilder then [ "dune"; "jbuilder" ] else [ "dune" ] in
+  depends_on_any packages formula
 
 let pull_tree ~url ~hashes ~dir global_state =
   let dir_str = Fpath.to_string dir in

--- a/lib/opam.ml
+++ b/lib/opam.ml
@@ -7,7 +7,33 @@ let depends_on_any packages (formula : OpamTypes.filtered_formula) =
   in
   OpamFormula.fold_left (fun acc (name, _) -> acc || is_one_of_packages name) false formula
 
-let depends_on_compiler_variants formula = depends_on_any [ "ocaml-variants" ] formula
+let ocaml_options =
+  (* ocaml-options-vanilla is purposefully excluded from that list as it doesn't imply
+     a dependency towards ocaml-variants on its own. *)
+  [
+    "ocaml-option-32bit";
+    "ocaml-option-afl";
+    "ocaml-option-bytecode-only";
+    "ocaml-option-default-unsafe-string";
+    "ocaml-option-flambda";
+    "ocaml-option-fp";
+    "ocaml-option-musl";
+    "ocaml-option-nnp";
+    "ocaml-option-nnpchecker";
+    "ocaml-option-no-flat-float-array";
+    "ocaml-option-spacetime";
+    "ocaml-option-static";
+    "ocaml-options-only-afl";
+    "ocaml-options-only-flambda";
+    "ocaml-options-only-flambda-fp";
+    "ocaml-options-only-fp";
+    "ocaml-options-only-nnp";
+    "ocaml-options-only-nnpchecker";
+    "ocaml-options-only-no-flat-float-array";
+  ]
+
+let depends_on_compiler_variants formula =
+  depends_on_any ("ocaml-variants" :: ocaml_options) formula
 
 let depends_on_dune ~allow_jbuilder (formula : OpamTypes.filtered_formula) =
   let packages = if allow_jbuilder then [ "dune"; "jbuilder" ] else [ "dune" ] in

--- a/lib/opam.mli
+++ b/lib/opam.mli
@@ -49,7 +49,9 @@ val depends_on_dune : allow_jbuilder:bool -> OpamTypes.filtered_formula -> bool
 
 val depends_on_compiler_variants : OpamTypes.filtered_formula -> bool
 (** Returns whether the given depends field formula contains a dependency
-    towards a compiler variant (such as a compiler with flambda or afl enabled for instance). *)
+    towards a compiler variant (such as a compiler with flambda or afl enabled for instance).
+    This is detected by looking direct dependencies on ocaml-variants or dependencies on
+    any relevant ocaml-option-* packages. *)
 
 val pull_tree :
   url:OpamUrl.t ->

--- a/lib/opam.mli
+++ b/lib/opam.mli
@@ -47,6 +47,10 @@ end
 val depends_on_dune : allow_jbuilder:bool -> OpamTypes.filtered_formula -> bool
 (** Returns whether the given depends field formula contains a dependency to dune or jbuilder *)
 
+val depends_on_compiler_variants : OpamTypes.filtered_formula -> bool
+(** Returns whether the given depends field formula contains a dependency
+    towards a compiler variant (such as a compiler with flambda or afl enabled for instance). *)
+
 val pull_tree :
   url:OpamUrl.t ->
   hashes:OpamHash.t list ->

--- a/test/test_opam.ml
+++ b/test/test_opam.ml
@@ -77,8 +77,47 @@ let test_depends_on_compiler_variants =
   in
   [
     make_test ~name:"Depends on ocaml" ~input:{|[ "ocaml" {>= "4.11"} ]|} ~expected:false ();
-    make_test ~name:"Depends variant directly"
+    make_test ~name:"Depends on variant directly"
       ~input:{|[ "ocaml-variants" {= "4.11.1+flambda+afl"} ]|} ~expected:true ();
+    make_test ~name:"Depends on ocaml-option-vanilla" ~input:{|[ "ocaml-options-vanilla" ]|}
+      ~expected:false ();
+    make_test ~name:"Depends on ocaml-option-32bit" ~input:{|[ "ocaml-option-32bit" ]|}
+      ~expected:true ();
+    make_test ~name:"Depends on ocaml-option-afl" ~input:{|[ "ocaml-option-afl" ]|} ~expected:true
+      ();
+    make_test ~name:"Depends on ocaml-option-bytecode-only"
+      ~input:{|[ "ocaml-option-bytecode-only" ]|} ~expected:true ();
+    make_test ~name:"Depends on ocaml-option-default-unsafe-string"
+      ~input:{|[ "ocaml-option-default-unsafe-string" ]|} ~expected:true ();
+    make_test ~name:"Depends on ocaml-option-flambda" ~input:{|[ "ocaml-option-flambda" ]|}
+      ~expected:true ();
+    make_test ~name:"Depends on ocaml-option-fp" ~input:{|[ "ocaml-option-fp" ]|} ~expected:true ();
+    make_test ~name:"Depends on ocaml-option-musl" ~input:{|[ "ocaml-option-musl" ]|} ~expected:true
+      ();
+    make_test ~name:"Depends on ocaml-option-nnp" ~input:{|[ "ocaml-option-nnp" ]|} ~expected:true
+      ();
+    make_test ~name:"Depends on ocaml-option-nnpchecker" ~input:{|[ "ocaml-option-nnpchecker" ]|}
+      ~expected:true ();
+    make_test ~name:"Depends on ocaml-option-no-flat-float-array"
+      ~input:{|[ "ocaml-option-no-flat-float-array" ]|} ~expected:true ();
+    make_test ~name:"Depends on ocaml-option-spacetime" ~input:{|[ "ocaml-option-spacetime" ]|}
+      ~expected:true ();
+    make_test ~name:"Depends on ocaml-option-static" ~input:{|[ "ocaml-option-static" ]|}
+      ~expected:true ();
+    make_test ~name:"Depends on ocaml-options-only-afl" ~input:{|[ "ocaml-options-only-afl" ]|}
+      ~expected:true ();
+    make_test ~name:"Depends on ocaml-options-only-flambda"
+      ~input:{|[ "ocaml-options-only-flambda" ]|} ~expected:true ();
+    make_test ~name:"Depends on ocaml-options-only-flambda-fp"
+      ~input:{|[ "ocaml-options-only-flambda-fp" ]|} ~expected:true ();
+    make_test ~name:"Depends on ocaml-options-only-fp" ~input:{|[ "ocaml-options-only-fp" ]|}
+      ~expected:true ();
+    make_test ~name:"Depends on ocaml-options-only-nnp" ~input:{|[ "ocaml-options-only-nnp" ]|}
+      ~expected:true ();
+    make_test ~name:"Depends on ocaml-options-only-nnpchecker"
+      ~input:{|[ "ocaml-options-only-nnpchecker" ]|} ~expected:true ();
+    make_test ~name:"Depends on ocaml-options-only-no-flat-float-array"
+      ~input:{|[ "ocaml-options-only-no-flat-float-array" ]|} ~expected:true ();
   ]
 
 let suite =

--- a/test/test_opam.ml
+++ b/test/test_opam.ml
@@ -65,4 +65,22 @@ let test_depends_on_dune =
       ~expected:true ();
   ]
 
-let suite = ("Opam", List.concat [ Url.test_from_opam; test_depends_on_dune ])
+let test_depends_on_compiler_variants =
+  let make_test ~name ~input ~expected () =
+    let test_name = Printf.sprintf "depends_on_compiler_variants: %s" name in
+    let test_fun () =
+      let formula = opam_parse_formula input in
+      let actual = Duniverse_lib.Opam.depends_on_compiler_variants formula in
+      Alcotest.(check bool) test_name expected actual
+    in
+    (test_name, `Quick, test_fun)
+  in
+  [
+    make_test ~name:"Depends on ocaml" ~input:{|[ "ocaml" {>= "4.11"} ]|} ~expected:false ();
+    make_test ~name:"Depends variant directly"
+      ~input:{|[ "ocaml-variants" {= "4.11.1+flambda+afl"} ]|} ~expected:true ();
+  ]
+
+let suite =
+  ( "Opam",
+    List.concat [ Url.test_from_opam; test_depends_on_dune; test_depends_on_compiler_variants ] )


### PR DESCRIPTION
This was causing the solver to select unreleased ocaml versions sometimes because their dependency could be met using packages such as `ocaml-variants.4.11.3+trunk`.

The variant selected this way made no particular sense as well since the solver was picking the highest version number according to the `+<variant-feature>` suffixes.

The solution is now required to include an `ocaml-base-compiler` unless one the local packages explicitly depends on an `ocaml-variants` package or one of the `ocaml-option-*` packages.