### PR TITLE
Make lock 2x faster by loading repo state once

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,9 @@
 
 ### Fixed
 
+- Improve `lock` performance (about 2x faster) by loading the repository state
+  only once (#188, @emillon)
+
 ### Removed
 
 ### Security


### PR DESCRIPTION
If no `~rt` argument is passed to `OpamSwitchState.with_`, it will load the repository state itself. We already load this state in `check_repo_config`, so this was causing it to be loaded twice.

Instead, we can load it manually and pass it as argument and it will use it.

Since that function dominates lock time, this makes lock twice as fast (on opam-monorepo itself: 12.4s down to 6.7s).
