### PR TITLE
Fix dune-project handling under windows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,10 @@
 - Fix a bug where the dune-project parsing in the `pull` command would fail
   if it used CRLF for new lines. (#191, @NathanReb)
 
+- Simply warn instead of exiting when the dune-project file can't be parsed
+  by `pull` as it only use it to suggest updating the lang version for
+  convenience (#191, @NathanReb)
+
 ### Removed
 
 ### Security

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,9 @@
 - Improve `lock` performance (about 2x faster) by loading the repository state
   only once (#188, @emillon)
 
+- Fix a bug where the dune-project parsing in the `pull` command would fail
+  if it used CRLF for new lines. (#191, @NathanReb)
+
 ### Removed
 
 ### Security

--- a/cli/pull.ml
+++ b/cli/pull.ml
@@ -29,7 +29,7 @@ let suggest_setting_version ~yes ~dune_project_path ~content =
   Common.Logs.app (fun l ->
       l "Your dune-project file doesn't specify a dune language version");
   if should_update_lang ~yes () then (
-    let updated = Dune_file.Lang.append ~version:min_dune_ver content in
+    let updated = Dune_file.Lang.prepend ~version:min_dune_ver content in
     log_version_update ~dune_project_path;
     Bos.OS.File.write dune_project_path updated)
   else Ok ()

--- a/cli/pull.ml
+++ b/cli/pull.ml
@@ -2,11 +2,6 @@ open Import
 
 let min_dune_ver = Dune_file.Lang.duniverse_minimum_version
 
-let update_lang ~content =
-  List.map content ~f:(fun line ->
-      if Dune_file.Lang.is_stanza line then Dune_file.Raw.duniverse_minimum_lang
-      else line)
-
 let should_update_lang ~yes () =
   Prompt.confirm
     ~question:(fun l -> l "Should I update your dune-project?")
@@ -25,18 +20,18 @@ let suggest_updating_version ~yes ~version ~dune_project_path ~content =
   Common.Logs.app (fun l ->
       l "Duniverse requires version %a or above" pp_required min_dune_ver);
   if should_update_lang ~yes () then (
-    let updated = update_lang ~content @ [ "" ] in
+    let updated = Dune_file.Lang.update ~version:min_dune_ver content in
     log_version_update ~dune_project_path;
-    Bos.OS.File.write_lines dune_project_path updated)
+    Bos.OS.File.write dune_project_path updated)
   else Ok ()
 
 let suggest_setting_version ~yes ~dune_project_path ~content =
   Common.Logs.app (fun l ->
       l "Your dune-project file doesn't specify a dune language version");
   if should_update_lang ~yes () then (
-    let updated = Dune_file.Raw.duniverse_minimum_lang :: content in
+    let updated = Dune_file.Lang.append ~version:min_dune_ver content in
     log_version_update ~dune_project_path;
-    Persist.write_lines_hum dune_project_path updated)
+    Bos.OS.File.write dune_project_path updated)
   else Ok ()
 
 let check_dune_lang_version ~yes ~repo =
@@ -46,12 +41,11 @@ let check_dune_lang_version ~yes ~repo =
       l "Looking for dune-project file in %a" Pp.Styled.path dune_project_path);
   Bos.OS.File.exists dune_project_path >>= fun found_dune_project ->
   if found_dune_project then
-    Bos.OS.File.read_lines dune_project_path >>= fun content ->
-    let lang_stanza = List.find_opt ~f:Dune_file.Lang.is_stanza content in
-    match lang_stanza with
+    Bos.OS.File.read dune_project_path >>= fun content ->
+    Dune_file.Lang.from_content content >>= fun version ->
+    match version with
     | None -> suggest_setting_version ~yes ~dune_project_path ~content
-    | Some s -> (
-        Dune_file.Lang.parse_stanza s >>= fun version ->
+    | Some version -> (
         let compared =
           Dune_file.Lang.(compare_version version duniverse_minimum_version)
         in

--- a/dune-project
+++ b/dune-project
@@ -16,6 +16,7 @@ code required to build a project using the dune build tool.")
  (depends
   (ocaml (>= 4.08.0))
   dune-build-info
+  base
   bos
   cmdliner
   fmt

--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,4 @@
 (library
  (name duniverse_lib)
- (libraries bos fmt logs lwt.unix ocaml-version opam-0install
+ (libraries base bos fmt logs lwt.unix ocaml-version opam-0install
    opam-file-format opam-format sexplib stdext threads uri))

--- a/lib/dune_file.ml
+++ b/lib/dune_file.ml
@@ -35,8 +35,7 @@ module Lang = struct
     match (int_of_string_opt major_str, int_of_string_opt minor_str) with
     | Some major, Some minor -> Ok (major, minor)
     | _ ->
-        Printf.ksprintf
-          (fun msg -> Error (`Msg msg))
+        Rresult.R.error_msgf
           "Invalid dune-project file: invalid lang version %s.%s" major_str
           minor_str
 
@@ -46,8 +45,7 @@ module Lang = struct
     | _ ->
         (* We match on [bos], meaning the only possible case here is the empty
            list *)
-        Printf.ksprintf
-          (fun msg -> Error (`Msg msg))
+        Rresult.R.error_msg
           "Invalid dune-project file: It does not start with a valid lang \
            stanza"
 

--- a/lib/dune_file.ml
+++ b/lib/dune_file.ml
@@ -63,7 +63,7 @@ module Lang = struct
 
   let stanza version = Format.asprintf "(lang dune %a)" pp_version version
 
-  let append ~version content =
+  let prepend ~version content =
     let contains_crlf = Base.String.is_substring ~substring:"\r\n" content in
     let newline = if contains_crlf then "\r\n" else "\n" in
     stanza version ^ newline ^ content

--- a/lib/dune_file.ml
+++ b/lib/dune_file.ml
@@ -9,24 +9,25 @@ module Lang = struct
 
   let stanza_regexp =
     let open Re in
-    seq
-      [
-        bol;
-        char '(';
-        rep blank;
-        str "lang";
-        rep1 blank;
-        str "dune";
-        rep1 blank;
-        group (rep1 digit);
-        char '.';
-        group (rep1 digit);
-        rep blank;
-        char ')';
-        rep blank;
-        opt (char '\r');
-        eol;
-      ]
+    compile
+      (seq
+         [
+           bol;
+           char '(';
+           rep blank;
+           str "lang";
+           rep1 blank;
+           str "dune";
+           rep1 blank;
+           group (rep1 digit);
+           char '.';
+           group (rep1 digit);
+           rep blank;
+           char ')';
+           rep blank;
+           opt (char '\r');
+           eol;
+         ])
 
   let from_match group =
     let major_str = Re.Group.get group 1 in
@@ -40,8 +41,7 @@ module Lang = struct
 
   let from_content content =
     let open Result.O in
-    let cregexp = Re.compile stanza_regexp in
-    match Re.all cregexp content with
+    match Re.all stanza_regexp content with
     | [] -> Ok None
     | [ group ] -> from_match group >>= fun version -> Ok (Some version)
     | _ ->
@@ -58,8 +58,7 @@ module Lang = struct
     Base.String.substr_replace_first ~pattern:old_ver ~with_:new_ver stanza
 
   let update ~version content =
-    let cregexp = Re.compile stanza_regexp in
-    Re.replace ~all:false cregexp ~f:(update_stanza ~version) content
+    Re.replace ~all:false stanza_regexp ~f:(update_stanza ~version) content
 
   let stanza version = Format.asprintf "(lang dune %a)" pp_version version
 

--- a/lib/dune_file.mli
+++ b/lib/dune_file.mli
@@ -9,9 +9,6 @@ module Raw : sig
 
   val duniverse_dune_content : string list
   (** The content of the duniverse/dune file as a list of lines *)
-
-  val duniverse_minimum_lang : string
-  (** The lang stanza setting the dune language to the minimum version required by duniverse *)
 end
 
 module Lang : sig
@@ -24,13 +21,18 @@ module Lang : sig
   val duniverse_minimum_version : version
   (** The minimum dune lang version required by duniverse *)
 
-  val parse_version : string -> (version, Rresult.R.msg) result
+  val from_content : string -> (version option, [> `Msg of string ]) result
+  (** Extract the lang version from the content of the entire dune-project *)
 
-  val parse_stanza : string -> (version, Rresult.R.msg) result
-  (** Parse the given lang stanza and return the dune language version *)
+  val update : version:version -> string -> string
+  (** Update the content of the entire dune-project, setting the lang version
+      to [version].
+      Return the string unmodified if there was previously no lang stanza. *)
 
-  val is_stanza : string -> bool
-  (** Tells whether the given dune-project file line is a lang stanza *)
+  val append : version:version -> string -> string
+  (** Append a lang stanza, using the given version to the dune-project
+      content.
+      Assume there is no lang stanza. *)
 end
 
 module Project : sig

--- a/lib/dune_file.mli
+++ b/lib/dune_file.mli
@@ -21,18 +21,13 @@ module Lang : sig
   val duniverse_minimum_version : version
   (** The minimum dune lang version required by duniverse *)
 
-  val from_content : string -> (version option, [> `Msg of string ]) result
+  val from_content : string -> (version, [> `Msg of string ]) result
   (** Extract the lang version from the content of the entire dune-project *)
 
   val update : version:version -> string -> string
   (** Update the content of the entire dune-project, setting the lang version
       to [version].
       Return the string unmodified if there was previously no lang stanza. *)
-
-  val prepend : version:version -> string -> string
-  (** Prepend a lang stanza, using the given version to the dune-project
-      content.
-      Assume there is no lang stanza. *)
 end
 
 module Project : sig

--- a/lib/dune_file.mli
+++ b/lib/dune_file.mli
@@ -29,8 +29,8 @@ module Lang : sig
       to [version].
       Return the string unmodified if there was previously no lang stanza. *)
 
-  val append : version:version -> string -> string
-  (** Append a lang stanza, using the given version to the dune-project
+  val prepend : version:version -> string -> string
+  (** Prepend a lang stanza, using the given version to the dune-project
       content.
       Assume there is no lang stanza. *)
 end

--- a/opam-monorepo.opam
+++ b/opam-monorepo.opam
@@ -16,6 +16,7 @@ depends: [
   "dune" {>= "2.6"}
   "ocaml" {>= "4.08.0"}
   "dune-build-info"
+  "base"
   "bos"
   "cmdliner"
   "fmt"

--- a/test/test_dune_file.ml
+++ b/test/test_dune_file.ml
@@ -53,11 +53,11 @@ module Lang = struct
         ~content:"(lang dune 1.2)\r\n(name my-project)\r\n" ();
     ]
 
-  let append =
+  let prepend =
     let make_test ~name ~version ~content ~expected () =
-      let test_name = Printf.sprintf "Lang.append: %s" name in
+      let test_name = Printf.sprintf "Lang.prepend: %s" name in
       let test_fun () =
-        let actual = Duniverse_lib.Dune_file.Lang.append ~version content in
+        let actual = Duniverse_lib.Dune_file.Lang.prepend ~version content in
         Alcotest.(check string) test_name expected actual
       in
       (test_name, `Quick, test_fun)
@@ -72,4 +72,4 @@ module Lang = struct
 end
 
 let suite =
-  ("Dune_file", List.concat [ Lang.from_content; Lang.update; Lang.append ])
+  ("Dune_file", List.concat [ Lang.from_content; Lang.update; Lang.prepend ])

--- a/test/test_dune_file.ml
+++ b/test/test_dune_file.ml
@@ -1,59 +1,75 @@
 module Lang = struct
-  let parse_version =
-    let make_test ~version ~expected () =
-      let test_name = Printf.sprintf "Lang.parse_version: %s" version in
+  let from_content =
+    let make_test ~name ~content ~expected () =
+      let test_name = Printf.sprintf "Lang.from_content: %s" name in
       let test_fun () =
-        let actual = Duniverse_lib.Dune_file.Lang.parse_version version in
-        Alcotest.(check (result (pair int int) Testable.r_msg))
+        let actual = Duniverse_lib.Dune_file.Lang.from_content content in
+        Alcotest.(check (result (option (pair int int)) Testable.r_msg))
           test_name expected actual
       in
       (test_name, `Quick, test_fun)
     in
     [
-      make_test ~version:"1.6" ~expected:(Ok (1, 6)) ();
-      make_test ~version:"1.x"
-        ~expected:(Error (`Msg "Invalid dune lang version: 1.x"))
-        ();
-      make_test ~version:"ver"
-        ~expected:(Error (`Msg "Invalid dune lang version: ver"))
-        ();
+      make_test ~name:"Empty dune-project" ~content:"" ~expected:(Ok None) ();
+      make_test ~name:"Valid version"
+        ~expected:(Ok (Some (1, 2)))
+        ~content:"(lang dune 1.2)" ();
+      make_test ~name:"Newlines"
+        ~expected:(Ok (Some (1, 2)))
+        ~content:"(lang dune 1.2)\n(name my-project)\n\n" ();
+      make_test ~name:"Windows newlines"
+        ~expected:(Ok (Some (1, 2)))
+        ~content:"(lang dune 1.2)\r\n(name my-project)\r\n\r\n" ();
+      make_test ~name:"Invalid version"
+        ~expected:
+          (Error
+             (`Msg "Invalid dune lang version: 1.999999999999999999999999999"))
+        ~content:"(lang dune 1.999999999999999999999999999)" ();
+      make_test ~name:"Multiple lang stanzas"
+        ~expected:
+          (Error (`Msg "Invalid dune-project file: Multiple lang stanzas"))
+        ~content:"(lang dune 1.2)\n(name my-project)\n(lang dune 1.3)\n" ();
     ]
 
-  let parse_stanza =
-    let make_test ~stanza ~expected () =
-      let test_name = Printf.sprintf "Lang.parse_stanza: %s" stanza in
+  let update =
+    let make_test ~name ~version ~content ~expected () =
+      let test_name = Printf.sprintf "Lang.update: %s" name in
       let test_fun () =
-        let actual = Duniverse_lib.Dune_file.Lang.parse_stanza stanza in
-        Alcotest.(check (result (pair int int) Testable.r_msg))
-          test_name expected actual
+        let actual = Duniverse_lib.Dune_file.Lang.update ~version content in
+        Alcotest.(check string) test_name expected actual
       in
       (test_name, `Quick, test_fun)
     in
     [
-      make_test ~stanza:"(lang dune 1.6)" ~expected:(Ok (1, 6)) ();
-      make_test ~stanza:"(lang dune ver)"
-        ~expected:(Error (`Msg "Invalid dune lang version: ver"))
-        ();
-      make_test ~stanza:"(lang something)"
-        ~expected:(Error (`Msg "Invalid lang stanza: (lang something)"))
-        ();
+      make_test ~name:"No stanza" ~version:(1, 3) ~expected:"(name my-project)"
+        ~content:"(name my-project)" ();
+      make_test ~name:"Replace" ~version:(1, 3) ~expected:"(lang dune 1.3)"
+        ~content:"(lang dune 1.2)" ();
+      make_test ~name:"Newlines" ~version:(1, 3)
+        ~expected:"(lang dune 1.3)\n(name my-project)\n"
+        ~content:"(lang dune 1.2)\n(name my-project)\n" ();
+      make_test ~name:"Windows newlines" ~version:(1, 3)
+        ~expected:"(lang dune 1.3)\r\n(name my-project)\r\n"
+        ~content:"(lang dune 1.2)\r\n(name my-project)\r\n" ();
     ]
 
-  let is_stanza =
-    let make_test ~line ~expected () =
-      let test_name = Printf.sprintf "Lang.is_stanza: %s" line in
+  let append =
+    let make_test ~name ~version ~content ~expected () =
+      let test_name = Printf.sprintf "Lang.append: %s" name in
       let test_fun () =
-        let actual = Duniverse_lib.Dune_file.Lang.is_stanza line in
-        Alcotest.(check bool) test_name expected actual
+        let actual = Duniverse_lib.Dune_file.Lang.append ~version content in
+        Alcotest.(check string) test_name expected actual
       in
       (test_name, `Quick, test_fun)
     in
     [
-      make_test ~line:"; a comment" ~expected:false ();
-      make_test ~line:"(name project)" ~expected:false ();
-      make_test ~line:"(lang dune 1.6)" ~expected:true ();
+      make_test ~name:"Empty" ~version:(1, 3) ~expected:"(lang dune 1.3)\n"
+        ~content:"" ();
+      make_test ~name:"Windows newlines" ~version:(1, 3)
+        ~expected:"(lang dune 1.3)\r\n(name my-project)\r\n"
+        ~content:"(name my-project)\r\n" ();
     ]
 end
 
 let suite =
-  ("Dune_file", Lang.parse_version @ Lang.parse_stanza @ Lang.is_stanza)
+  ("Dune_file", List.concat [ Lang.from_content; Lang.update; Lang.append ])


### PR DESCRIPTION
This used to crash under some circumstances on windows machines because it wouldn't handle CRLF properly.
The new code uses regexp to properly extract the version without being sensitive to leftover CR and replace just the version number, without modifying the rest of the file, including of course, CRLF.

I also updated the code that appends a lang stanza even though it's unlikely we'll need it again for a very long time. It now tries to
respect the newline convention found inside the file, defaulting to good old `\n` if it can't figure it out.

Finally, I added a bunch of unit tests for this in the process.