### PR TITLE
Access repo state through switch state

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@
 ### Fixed
 
 - Improve `lock` performance (about 2x faster) by loading the repository state
-  only once (#188, @emillon)
+  only once (#188, #192, @emillon)
 
 - Fix a bug where the dune-project parsing in the `pull` command would fail
   if it used CRLF for new lines. (#191, @NathanReb)


### PR DESCRIPTION
This simplifies a bit how states are loaded:
- repo state is automatically loaded when switch state is loaded
- repo state can be accessed as a field of switch state
