### PR TITLE
Commit_pointed_by: partial support when ref is a commit

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,11 @@
   `.opam.locked` file and pulls it unless there are multiple matching files in
   the repository's root. (#163, @NathanReb)
 
+- Fix failure when a package is pinned to a specific commit. `lock` now skips
+  resolution when the ref is actually a commit pointed by a remote branch or 
+  when it looks like a commit (hexadecimal characters only, at least 7 
+  characters-long). (#195, fixes #127, @TheLortex)
+
 ### Removed
 
 ### Security

--- a/test/test_git.ml
+++ b/test/test_git.ml
@@ -127,6 +127,13 @@ module Ls_remote = struct
         ~lines:[ "001   refs/heads/xabc" ]
         ~expected:(Error `No_such_ref)
         ();
+      make_test ~name:"Ref is a commit" ~ref:"000456"
+        ~lines:[ "00017f   refs/heads/master"; "000456   refs/heads/abc" ]
+        ~expected:(Ok "000456") ();
+      make_test ~name:"Ref looks like a commit"
+        ~ref:"7af9de1c4c468d8fd0f2870b98355803bcfd76f7"
+        ~lines:[ "000000   refs/heads/master" ]
+        ~expected:(Ok "7af9de1c4c468d8fd0f2870b98355803bcfd76f7") ();
     ]
 
   let test_branch_of_symref =


### PR DESCRIPTION
Fixes https://github.com/ocamllabs/opam-monorepo/issues/127

In the ref resolution we can check if a commit exists when it's pointed by an existing ref. 
Otherwise we just check if it looks like a commit (hex numbers), assume it exists in the remote and emit a warning. 