### PR TITLE
Set the `root_dir` in the OPAM state

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,17 @@
+## unreleased
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Fixed
+
+### Removed
+
+### Security
+
 ## 0.2.4
 
 ### Added

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,9 @@
 
 ### Fixed
 
+- Fix setting `OPAMROOT` to accept non-default paths (#197, #198,
+  @Leonidas-from-XIV)
+
 ### Removed
 
 ### Security

--- a/bin/opam_monorepo.ml
+++ b/bin/opam_monorepo.ml
@@ -25,7 +25,7 @@ let init_opam () =
   OpamFormatConfig.init ();
   OpamCoreConfig.init ~safe_mode:true ();
   OpamRepositoryConfig.init ();
-  OpamStateConfig.init ()
+  OpamStateConfig.init ~root_dir:root ()
 
 let () =
   init_opam ();

--- a/cli/dune
+++ b/cli/dune
@@ -1,4 +1,12 @@
 (library
  (name duniverse_cli)
- (libraries duniverse_lib fmt.cli fmt.tty logs.cli logs.fmt cmdliner lwt.unix
-   dune-build-info ocaml-version))
+ (libraries
+  duniverse_lib
+  fmt.cli
+  fmt.tty
+  logs.cli
+  logs.fmt
+  cmdliner
+  lwt.unix
+  dune-build-info
+  ocaml-version))

--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,16 @@
 (library
  (name duniverse_lib)
- (libraries base bos fmt logs lwt.unix ocaml-version opam-0install
-   opam-file-format opam-format sexplib stdext threads uri))
+ (libraries
+  base
+  bos
+  fmt
+  logs
+  lwt.unix
+  ocaml-version
+  opam-0install
+  opam-file-format
+  opam-format
+  sexplib
+  stdext
+  threads
+  uri))


### PR DESCRIPTION
If not set then OPAM does not set the right path for the OPAM root and will use the default `~/.opam` no matter what. The OPAM API is surprising in this regard that even passing the root folder to `load_defaults` does not actually end up setting the folder.

Closes #197