### PR TITLE
[Preview] upgrade to ocamlformat.0.20.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,2 +1,2 @@
-version=0.19.0
+version=0.20.0
 profile=conventional

--- a/cli/common.ml
+++ b/cli/common.ml
@@ -2,7 +2,6 @@ open Import
 
 module Arg = struct
   let named f = Cmdliner.Term.(app (const f))
-
   let fpath = Cmdliner.Arg.conv ~docv:"PATH" (Fpath.of_string, Fpath.pp)
 
   let repo =

--- a/cli/default.ml
+++ b/cli/default.ml
@@ -32,5 +32,4 @@ let info =
     ~man
 
 let term = Cmdliner.Term.(ret (const run $ pure ()))
-
 let cmd = (term, info)

--- a/cli/dune
+++ b/cli/dune
@@ -1,4 +1,12 @@
 (library
  (name duniverse_cli)
- (libraries duniverse_lib fmt.cli fmt.tty logs.cli logs.fmt cmdliner
-   dune-build-info ocaml-version opam-state))
+ (libraries
+  duniverse_lib
+  fmt.cli
+  fmt.tty
+  logs.cli
+  logs.fmt
+  cmdliner
+  dune-build-info
+  ocaml-version
+  opam-state))

--- a/cli/lock.ml
+++ b/cli/lock.ml
@@ -4,13 +4,9 @@ module Package_argument : sig
   type t
 
   val make : name:string -> version:OpamPackage.Version.t option -> t
-
   val name : t -> OpamPackage.Name.t
-
   val version : t -> OpamPackage.Version.t option
-
   val converter : t Cmdliner.Arg.converter
-
   val pp_styled : t Fmt.t
 end = struct
   type t = { name : OpamPackage.Name.t; version : OpamPackage.Version.t option }
@@ -20,7 +16,6 @@ end = struct
     { name; version }
 
   let name { name; _ } = name
-
   let version { version; _ } = version
 
   let from_string name =

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -31,21 +31,13 @@ let duniverse_opam_repo =
   "git+https://github.com/dune-universe/opam-overlays.git"
 
 let dune_get = Fpath.v "dune-get"
-
 let vendor_dir = Fpath.v "duniverse"
-
 let pins_dir = Fpath.(vendor_dir / ".pins")
-
 let duniverse_log = Fpath.v ".duniverse-log"
-
 let bootstrap_dir = Fpath.v "_ocaml"
-
 let bootstrap_src_dir = Fpath.(bootstrap_dir / "src")
-
 let ocaml_src_dir = Fpath.(bootstrap_src_dir / "ocaml")
-
 let dune_src_dir = Fpath.(bootstrap_src_dir / "dune")
-
 let dune_latest_tag = "2.6.0" (* TODO get from opam metadata *)
 
 let lockfile_ext = ".opam.locked"

--- a/lib/dev_repo.ml
+++ b/lib/dev_repo.ml
@@ -3,9 +3,7 @@ open Import
 type t = string
 
 let compare = String.compare
-
 let from_string s = s
-
 let to_string t = t
 
 let repo_name t =

--- a/lib/dev_repo.mli
+++ b/lib/dev_repo.mli
@@ -3,7 +3,6 @@ open Import
 type t
 
 val from_string : string -> t
-
 val to_string : t -> string
 
 val repo_name : t -> string

--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,15 @@
 (library
  (name duniverse_lib)
- (libraries base bos fmt logs ocaml-version opam-0install opam-file-format
-   opam-format sexplib stdext threads uri))
+ (libraries
+  base
+  bos
+  fmt
+  logs
+  ocaml-version
+  opam-0install
+  opam-file-format
+  opam-format
+  sexplib
+  stdext
+  threads
+  uri))

--- a/lib/dune_file.ml
+++ b/lib/dune_file.ml
@@ -4,7 +4,6 @@ module Lang = struct
   type version = int * int
 
   let pp_version fmt (major, minor) = Format.fprintf fmt "%d.%d" major minor
-
   let version_to_string version = Format.asprintf "%a" pp_version version
 
   let stanza_regexp =
@@ -83,7 +82,6 @@ module Raw = struct
                Fpath.pp path))
 
   let comment s = Printf.sprintf "; %s" s
-
   let vendored_dirs glob = Printf.sprintf "(vendored_dirs %s)" glob
 
   let duniverse_dune_content =

--- a/lib/dune_file.mli
+++ b/lib/dune_file.mli
@@ -15,7 +15,6 @@ module Lang : sig
   type version = int * int
 
   val compare_version : version -> version -> int
-
   val pp_version : version Fmt.t
 
   val duniverse_minimum_version : version

--- a/lib/duniverse.ml
+++ b/lib/duniverse.ml
@@ -2,7 +2,6 @@ open Import
 module O = Opam
 
 type unresolved = Git.Ref.t
-
 type resolved = Git.Ref.resolved
 
 module Opam = struct

--- a/lib/duniverse.mli
+++ b/lib/duniverse.mli
@@ -1,7 +1,6 @@
 module O = Opam
 
 type unresolved = Git.Ref.t
-
 type resolved = Git.Ref.resolved
 
 module Opam : sig
@@ -9,11 +8,8 @@ module Opam : sig
   (** Type of dependencies to install through opam *)
 
   val equal : t -> t -> bool
-
   val pp : t Fmt.t
-
   val to_opam : t -> OpamPackage.t
-
   val from_opam : OpamPackage.t -> t
 end
 
@@ -22,11 +18,8 @@ module Repo : sig
     type 'ref t = Git of { repo : string; ref : 'ref } | Other of string
 
     val equal : ('ref -> 'ref -> bool) -> 'ref t -> 'ref t -> bool
-
     val pp : 'ref Fmt.t -> 'ref t Fmt.t
-
     val to_string : resolved t -> string
-
     val to_opam_url : resolved t -> OpamUrl.t
 
     val from_opam_url : OpamUrl.t -> (resolved t, [ `Msg of string ]) result
@@ -59,7 +52,6 @@ module Repo : sig
     }
 
     val equal : t -> t -> bool
-
     val pp : t Fmt.t
 
     val from_package_summary :

--- a/lib/exec.mli
+++ b/lib/exec.mli
@@ -15,9 +15,7 @@
  *)
 
 val map : ('a -> ('b, 'c) result) -> 'a list -> ('b list, 'c) result
-
 val iter : ('a -> (unit, 'b) result) -> 'a list -> (unit, 'b) result
-
 val opam_version : unit -> (string, [> Rresult.R.msg ]) result
 
 val ocaml_version :

--- a/lib/git.ml
+++ b/lib/git.ml
@@ -2,7 +2,6 @@ open Import
 
 module Ls_remote = struct
   let non_packed_suffix = "^{}"
-
   let ref_arg ref = Bos.Cmd.(v ref % (ref ^ non_packed_suffix))
 
   let parse_output_line s =
@@ -95,9 +94,7 @@ module Ref = struct
   type t = string
 
   let equal = String.equal
-
   let compare = String.compare
-
   let pp = Format.pp_print_string
 
   type resolved = { t : t; commit : string }

--- a/lib/git.mli
+++ b/lib/git.mli
@@ -33,14 +33,11 @@ module Ref : sig
   type t = string
 
   val compare : t -> t -> int
-
   val equal : t -> t -> bool
-
   val pp : t Fmt.t
 
   type resolved = { t : t; commit : string } [@@deriving sexp]
 
   val equal_resolved : resolved -> resolved -> bool
-
   val pp_resolved : resolved Fmt.t
 end

--- a/lib/lockfile.ml
+++ b/lib/lockfile.ml
@@ -4,9 +4,7 @@ module Pos = struct
   open OpamParserTypes.FullPos
 
   let default = { filename = "None"; start = (0, 0); stop = (0, 0) }
-
   let from_value { pos; _ } = pos
-
   let with_default_pos pelem = { pos = default; pelem }
 
   let errorf ~pos fmt =
@@ -55,9 +53,7 @@ module Version = struct
   type t = int * int
 
   let current = (0, 2)
-
   let pp fmt (major, minor) = Format.fprintf fmt "%d.%d" major minor
-
   let to_string (major, minor) = Printf.sprintf "%d.%d" major minor
 
   let from_string s =

--- a/lib/lockfile.mli
+++ b/lib/lockfile.mli
@@ -9,9 +9,6 @@ val create :
   t
 
 val to_duniverse : t -> (Duniverse.t, [ `Msg of string ]) result
-
 val save : file:Fpath.t -> t -> (unit, [ `Msg of string ]) result
-
 val load : file:Fpath.t -> (t, [ `Msg of string ]) result
-
 val depexts : t -> (OpamSysPkg.Set.t * OpamTypes.filter) list

--- a/lib/opam.ml
+++ b/lib/opam.ml
@@ -176,9 +176,7 @@ end
 
 module Pp = struct
   let package fmt p = Format.fprintf fmt "%s" (OpamPackage.to_string p)
-
   let hash = Hash.pp
-
   let url fmt url = Format.fprintf fmt "%s" (OpamUrl.to_string url)
 end
 

--- a/lib/opam.mli
+++ b/lib/opam.mli
@@ -4,11 +4,8 @@ module Url : sig
   (* This includes archives, other VCS and rsync opam src URLs *)
 
   val equal : t -> t -> bool
-
   val pp : t Fmt.t
-
   val from_opam_field : OpamFile.URL.t -> t
-
   val from_opam : OpamUrl.t -> t
 end
 
@@ -23,9 +20,7 @@ module Package_summary : sig
   }
 
   val equal : t -> t -> bool
-
   val pp : t Fmt.t
-
   val from_opam : pkg:OpamPackage.t -> OpamFile.OPAM.t -> t
 
   val is_virtual : t -> bool
@@ -40,9 +35,7 @@ end
 
 module Pp : sig
   val package : OpamPackage.t Fmt.t
-
   val hash : OpamHash.t Fmt.t
-
   val url : OpamUrl.t Fmt.t
 end
 

--- a/lib/pin_depends.mli
+++ b/lib/pin_depends.mli
@@ -3,7 +3,6 @@ open! Import
 type t = OpamPackage.t * OpamUrl.t
 
 val equal : t -> t -> bool
-
 val pp : Format.formatter -> t -> unit
 
 val sort_uniq : t list -> (t list, [> `Msg of string ]) result

--- a/lib/pp.ml
+++ b/lib/pp.ml
@@ -5,21 +5,13 @@ let plural fmt l = Fmt.using List.length plural_int fmt l
 
 module Styled = struct
   let header = Fmt.(styled `Blue (const string "==> "))
-
   let question_header = Fmt.(styled `Magenta (const string "??? "))
-
   let header_indent = Fmt.(const string "    ")
-
   let branch = Fmt.(styled `Cyan string)
-
   let commit = branch
-
   let package_name = Fmt.(styled `Yellow string)
-
   let path fmt path = Fmt.(styled `Cyan Fpath.pp) fmt (Fpath.normalize path)
-
   let good pp = Fmt.(styled `Green pp)
-
   let bad pp = Fmt.(styled `Red pp)
 
   let cached fmt cached =

--- a/lib/pp.mli
+++ b/lib/pp.mli
@@ -1,24 +1,15 @@
 val plural : 'a list Fmt.t
-
 val plural_int : int Fmt.t
 
 module Styled : sig
   val header : unit Fmt.t
-
   val question_header : unit Fmt.t
-
   val header_indent : unit Fmt.t
-
   val branch : string Fmt.t
-
   val commit : string Fmt.t
-
   val package_name : string Fmt.t
-
   val path : Fpath.t Fmt.t
-
   val good : 'a Fmt.t -> 'a Fmt.t
-
   val bad : 'a Fmt.t -> 'a Fmt.t
 
   val cached : bool Fmt.t

--- a/lib/pp_combinators.ml
+++ b/lib/pp_combinators.ml
@@ -1,6 +1,5 @@
 module Ocaml = struct
   let string fmt s = Format.fprintf fmt "%S" s
-
   let bool fmt b = Format.fprintf fmt "%B" b
 
   let option ?(brackets = true) pp_a fmt = function

--- a/stdext/list.mli
+++ b/stdext/list.mli
@@ -3,15 +3,10 @@ include module type of struct
 end
 
 val is_empty : 'a t -> bool
-
 val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
-
 val find_map : 'a list -> f:('a -> 'b option) -> 'b option
-
 val partition_map : 'a t -> f:('a -> ('b, 'c) Either.t) -> 'b t * 'c t
-
 val filter_opt : 'a option t -> 'a t
-
 val concat_map : f:('a -> 'b list) -> 'a list -> 'b list
 
 val max_exn : compare:('a -> 'a -> int) -> 'a list -> 'a

--- a/stdext/map.ml
+++ b/stdext/map.ml
@@ -2,21 +2,13 @@ module type S = sig
   include MoreLabels.Map.S
 
   val mem : 'a t -> key -> bool
-
   val set : 'a t -> key -> 'a -> 'a t
-
   val find : 'a t -> key -> 'a option
-
   val update : 'a t -> key -> f:('a option -> 'a option) -> 'a t
-
   val values : 'a t -> 'a list
-
   val keys : 'a t -> key list
-
   val of_list : (key * 'a) list -> ('a t, key * 'a * 'a) Result.t
-
   val of_list_exn : (key * 'a) list -> 'a t
-
   val of_list_map_exn : 'a list -> f:('a -> key * 'b) -> 'b t
 end
 
@@ -28,17 +20,11 @@ module Make (Key : Key) : S with type key = Key.t = struct
   include MoreLabels.Map.Make (Key)
 
   let mem t k = mem k t
-
   let find key t = find_opt t key
-
   let update t k ~f = update ~key:k ~f t
-
   let set t k v = add ~key:k ~data:v t
-
   let foldi t ~init ~f = fold t ~init ~f:(fun ~key ~data acc -> f key data acc)
-
   let values t = foldi t ~init:[] ~f:(fun _ v l -> v :: l) |> List.rev
-
   let keys t = foldi t ~init:[] ~f:(fun k _ l -> k :: l) |> List.rev
 
   let of_list =

--- a/stdext/map.mli
+++ b/stdext/map.mli
@@ -2,21 +2,13 @@ module type S = sig
   include MoreLabels.Map.S
 
   val mem : 'a t -> key -> bool
-
   val set : 'a t -> key -> 'a -> 'a t
-
   val find : 'a t -> key -> 'a option
-
   val update : 'a t -> key -> f:('a option -> 'a option) -> 'a t
-
   val values : 'a t -> 'a list
-
   val keys : 'a t -> key list
-
   val of_list : (key * 'a) list -> ('a t, key * 'a * 'a) Result.t
-
   val of_list_exn : (key * 'a) list -> 'a t
-
   val of_list_map_exn : 'a list -> f:('a -> key * 'b) -> 'b t
 end
 

--- a/stdext/option.ml
+++ b/stdext/option.ml
@@ -1,14 +1,11 @@
 include Stdlib.Option
 
 let value ~default = function None -> default | Some x -> x
-
 let map ~f = function None -> None | Some x -> Some (f x)
-
 let bind ~f = function None -> None | Some x -> f x
 
 module O = struct
   let ( >>= ) opt f = bind ~f opt
-
   let ( >>| ) opt f = map ~f opt
 end
 

--- a/stdext/option.mli
+++ b/stdext/option.mli
@@ -4,14 +4,10 @@ end
 
 module O : sig
   val ( >>= ) : 'a t -> ('a -> 'b t) -> 'b t
-
   val ( >>| ) : 'a t -> ('a -> 'b) -> 'b t
 end
 
 val value : default:'a -> 'a t -> 'a
-
 val bind : f:('a -> 'b t) -> 'a t -> 'b t
-
 val map : f:('a -> 'b) -> 'a t -> 'b t
-
 val map_default : f:('a -> 'b) -> default:'b -> 'a t -> 'b

--- a/stdext/ordering.ml
+++ b/stdext/ordering.ml
@@ -1,15 +1,9 @@
 type t = Lt | Eq | Gt
 
 let of_int n = if n < 0 then Lt else if n = 0 then Eq else Gt
-
 let to_int = function Lt -> -1 | Eq -> 0 | Gt -> 1
-
 let to_string = function Lt -> "<" | Eq -> "=" | Gt -> ">"
-
 let neq = function Eq -> false | Lt | Gt -> true
-
 let is_eq = function Eq -> true | Lt | Gt -> false
-
 let min f x y = match f x y with Eq | Lt -> x | Gt -> y
-
 let max f x y = match f x y with Eq | Gt -> x | Lt -> y

--- a/stdext/ordering.mli
+++ b/stdext/ordering.mli
@@ -3,16 +3,12 @@
 type t = Lt  (** Lesser than *) | Eq  (** Equal *) | Gt  (** Greater than *)
 
 val of_int : int -> t
-
 val to_int : t -> int
 
 val to_string : t -> string
 (** returns the string representation. one of: "<", "=", ">" *)
 
 val neq : t -> bool
-
 val is_eq : t -> bool
-
 val min : ('a -> 'a -> t) -> 'a -> 'a -> 'a
-
 val max : ('a -> 'a -> t) -> 'a -> 'a -> 'a

--- a/stdext/result.ml
+++ b/stdext/result.ml
@@ -1,12 +1,10 @@
 include Stdlib.Result
 
 let bind ~f = function Error _ as err -> err | Ok x -> f x
-
 let map ~f = function Error _ as err -> err | Ok x -> Ok (f x)
 
 module O = struct
   let ( >>= ) res f = bind ~f res
-
   let ( >>| ) res f = map ~f res
 end
 

--- a/stdext/result.mli
+++ b/stdext/result.mli
@@ -3,12 +3,10 @@ include module type of struct
 end
 
 val bind : f:('a -> ('b, 'err) t) -> ('a, 'err) t -> ('b, 'err) t
-
 val map : f:('a -> 'b) -> ('a, 'err) t -> ('b, 'err) t
 
 module O : sig
   val ( >>= ) : ('a, 'err) t -> ('a -> ('b, 'err) t) -> ('b, 'err) t
-
   val ( >>| ) : ('a, 'err) t -> ('a -> 'b) -> ('b, 'err) t
 end
 
@@ -16,9 +14,7 @@ val map_error : f:('a -> 'b) -> ('ok, 'a) t -> ('ok, 'b) t
 
 module List : sig
   val map : f:('a -> ('b, 'err) t) -> 'a list -> ('b list, 'err) t
-
   val iter : f:('a -> (unit, 'err) t) -> 'a list -> (unit, 'err) t
-
   val all : ('a, 'error) t list -> ('a list, 'error) t
 
   val fold_left :

--- a/stdext/string.ml
+++ b/stdext/string.ml
@@ -47,7 +47,6 @@ let drop_suffix s ~suffix =
   else None
 
 let index = index_opt
-
 let rindex = rindex_opt
 
 let lsplit2 s ~on =

--- a/stdext/string.mli
+++ b/stdext/string.mli
@@ -3,21 +3,13 @@ include module type of struct
 end
 
 val index : string -> char -> int option
-
 val rindex : string -> char -> int option
-
 val lsplit2 : string -> on:char -> (string * string) option
-
 val rsplit2 : string -> on:char -> (string * string) option
-
 val extract_blank_separated_words : string -> string list
-
 val is_prefix : string -> prefix:string -> bool
-
 val is_suffix : string -> suffix:string -> bool
-
 val drop_prefix : string -> prefix:string -> string option
-
 val drop_suffix : string -> suffix:string -> string option
 
 module Map : Map.S with type key = string

--- a/test/test_opam.ml
+++ b/test/test_opam.ml
@@ -9,7 +9,6 @@ module Testable = struct
     open OpamPackage.Version
 
     let pp ppf v = Format.fprintf ppf "%s" (to_string v)
-
     let t = Alcotest.testable pp equal
   end
 end

--- a/test/testable.mli
+++ b/test/testable.mli
@@ -1,3 +1,2 @@
 val r_msg : Rresult.R.msg Alcotest.testable
-
 val sexp : Sexplib0.Sexp.t Alcotest.testable


### PR DESCRIPTION
This is a preview of the not-yet-released `ocamlformat.0.20.0`, please wait until the package is published in opam to merge this PR. The output is still likely to slightly change before the package is released.
The changes are due to:
- `module-item-spacing` is now set to `compact` for the default profile
- `module-item-spacing` is now correctly applied to mutually recursive type definitions