### PR TITLE
Rename Repo to Project

### DIFF
--- a/cli/common.ml
+++ b/cli/common.ml
@@ -123,7 +123,7 @@ let find_lockfile_aux ~explicit_lockfile repo =
   match explicit_lockfile with
   | Some file -> Ok file
   | None -> (
-      Repo.local_lockfiles repo >>= function
+      Project.local_lockfiles repo >>= function
       | [] ->
           Rresult.R.error_msg
             "No lockfile: try running `opam monorepo lock` first"

--- a/cli/lock.ml
+++ b/cli/lock.ml
@@ -132,10 +132,10 @@ let local_packages ~recurse ~explicit_list repo =
   let open Rresult.R.Infix in
   match explicit_list with
   | [] ->
-      Repo.local_packages ~recurse repo >>| fun local_paths ->
+      Project.local_packages ~recurse repo >>| fun local_paths ->
       String.Map.map ~f:(fun path -> (None, path)) local_paths
   | _ ->
-      Repo.local_packages ~recurse:true
+      Project.local_packages ~recurse:true
         ~filter:(List.map ~f:Package_argument.name explicit_list)
         repo
       >>= fun local_paths -> filter_local_packages ~explicit_list local_paths
@@ -168,7 +168,7 @@ let lockfile_path ~explicit_lockfile ~local_packages repo =
   match explicit_lockfile with
   | Some path -> Ok path
   | None ->
-      Repo.lockfile
+      Project.lockfile
         ~local_packages:(List.map ~f:Package_argument.name local_packages)
         repo
 

--- a/cli/pull.ml
+++ b/cli/pull.ml
@@ -27,7 +27,7 @@ let suggest_updating_version ~yes ~version ~dune_project_path ~content =
 
 let check_dune_lang_version ~yes ~root =
   let open Result.O in
-  let dune_project_path = Fpath.(root / "dune-project") in
+  let dune_project_path = Repo.dune_project root in
   Logs.debug (fun l ->
       l "Looking for dune-project file in %a" Pp.Styled.path dune_project_path);
   Bos.OS.File.exists dune_project_path >>= fun found_dune_project ->

--- a/cli/pull.ml
+++ b/cli/pull.ml
@@ -27,7 +27,7 @@ let suggest_updating_version ~yes ~version ~dune_project_path ~content =
 
 let check_dune_lang_version ~yes ~root =
   let open Result.O in
-  let dune_project_path = Repo.dune_project root in
+  let dune_project_path = Project.dune_project root in
   Logs.debug (fun l ->
       l "Looking for dune-project file in %a" Pp.Styled.path dune_project_path);
   Bos.OS.File.exists dune_project_path >>= fun found_dune_project ->

--- a/lib/project.ml
+++ b/lib/project.ml
@@ -49,7 +49,7 @@ let local_packages ~recurse ?filter t =
 
 let dune_project t = Fpath.(t / "dune-project")
 
-let project_name t =
+let name t =
   let open Result.O in
   let dune_project = dune_project t in
   Dune_file.Raw.as_sexps dune_project >>= Dune_file.Project.name
@@ -71,7 +71,7 @@ let lockfile ?local_packages:lp t =
   | [ name ] ->
       let name = OpamPackage.Name.to_string name in
       Ok (lockfile ~name t)
-  | _ -> project_name t >>= fun name -> Ok (lockfile ~name t)
+  | _ -> name t >>= fun name -> Ok (lockfile ~name t)
 
 let local_lockfiles repo =
   let open Result.O in

--- a/lib/project.mli
+++ b/lib/project.mli
@@ -1,7 +1,10 @@
 open Import
-(** Utility functions to extract repository specific path and values *)
+(** Utility functions to extract project specific path and values *)
 
 type t = Fpath.t
+(** The type of projects.
+    
+    What we consider a project here is the root of a dune project/workspace *)
 
 val local_packages :
   recurse:bool ->
@@ -16,19 +19,19 @@ val local_packages :
 val dune_project : t -> Fpath.t
 (** Returns the path to the dune-project file. *)
 
-val project_name : t -> (string, [> `Msg of string ]) result
+val name : t -> (string, [> `Msg of string ]) result
 (** Returns the name of the project, as set in the dune-project. *)
 
 val lockfile :
   ?local_packages:OpamPackage.Name.t list ->
   t ->
   (Fpath.t, [> `Msg of string ]) result
-(** Returns the path to the opam-monorepo lockfile for the given repo.
+(** Returns the path to the opam-monorepo lockfile for the given project.
     If the repo contains a single package, then it's the ["<package_name>.opam.locked"]
-    file at the root of the repo.
+    file at the root of the project.
     If it contains multiple packages, then it's the ["<project_name>.opam.locked"] file
-    at the root of the repo.
-    One can provide [local_packages] if they were already computed are if only a subset
+    at the root of the project.
+    One can provide [local_packages] if they were already computed or if only a subset
     of the local packages must be taken into account. *)
 
 val local_lockfiles : t -> (Fpath.t list, Rresult.R.msg) result


### PR DESCRIPTION
As a follow up to #218 I renamed the `Repo` module to `Project` which is more accurate of a name.

Also replaced a hand assembled dune-project path with a call to the proper function from the above mentioned module.