### PR TITLE
Add our fork of opam-0install-solver as a pin-depend

### DIFF
--- a/opam-monorepo.opam
+++ b/opam-monorepo.opam
@@ -38,3 +38,9 @@ conflicts: [
 dev-repo: "git+https://github.com/ocamllabs/opam-monorepo.git"
 build: [ "dune" "build" "-p" name "-j" jobs "@install" "@runtest" {with-test} ]
 flags: [ plugin ]
+pin-depends: [
+  [
+    "opam-0install"
+    "git+https://github.com/NathanReb/opam-0install-solver#0e3d946084d6da0aa33f0a0c61e0cc780025054e"
+  ]
+]

--- a/opam-monorepo.opam.template
+++ b/opam-monorepo.opam.template
@@ -1,2 +1,8 @@
 build: [ "dune" "build" "-p" name "-j" jobs "@install" "@runtest" {with-test} ]
 flags: [ plugin ]
+pin-depends: [
+  [
+    "opam-0install"
+    "git+https://github.com/NathanReb/opam-0install-solver#0e3d946084d6da0aa33f0a0c61e0cc780025054e"
+  ]
+]


### PR DESCRIPTION
As observed by @emillon `opam pin add opam-monorepo --dev` is failing because we're missing the pin in the original `opam` file. This adds it.

Tested on a fresh OPAM switch, it builds fine now.