### PR TITLE
Display the full solver error with --verbose

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@
 - Rename the `--repo` option to `--root` to make it more
   straightforward  that this is referring to the project root (#218, @samoht)
 - Improve the wording of the lockfile selection log (#222, @NathanReb)
-- Display the full solver error with `--verbose` (#<PR_NUMBER>, @emillon)
+- Display the full solver error with `--verbose` (#229, @emillon)
 
 ### Deprecated
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 - Rename the `--repo` option to `--root` to make it more
   straightforward  that this is referring to the project root (#218, @samoht)
 - Improve the wording of the lockfile selection log (#222, @NathanReb)
+- Display the full solver error with `--verbose` (#<PR_NUMBER>, @emillon)
 
 ### Deprecated
 

--- a/cli/lock.ml
+++ b/cli/lock.ml
@@ -184,6 +184,10 @@ let get_pin_depends ~global_state local_opam_files =
   let open Rresult.R.Infix in
   root_pin_depends local_opam_files >>= pull_pin_depends ~global_state
 
+let display_verbose_diagnostics = function
+  | None -> false
+  | Some l -> l >= Logs.Info
+
 let interpret_solver_error ~switch_state = function
   | `Msg _ as err -> err
   | `Diagnostics d ->
@@ -191,7 +195,8 @@ let interpret_solver_error ~switch_state = function
       | [] -> ()
       | offending_packages ->
           check_dune_universe_repo ~switch_state offending_packages);
-      Opam_solve.diagnostics_message d
+      let verbose = display_verbose_diagnostics (Logs.level ()) in
+      Opam_solve.diagnostics_message ~verbose d
 
 let calculate_opam ~build_only ~allow_jbuilder ~local_opam_files ~ocaml_version
     ~target_packages =

--- a/lib/opam_solve.ml
+++ b/lib/opam_solve.ml
@@ -158,8 +158,8 @@ let calculate_raw ~build_only ~allow_jbuilder ~ocaml_version ~local_packages
 
 type diagnostics = Local_solver.diagnostics
 
-let diagnostics_message diagnostics =
-  `Msg (Local_solver.diagnostics diagnostics)
+let diagnostics_message ~verbose diagnostics =
+  `Msg (Local_solver.diagnostics ~verbose diagnostics)
 
 module Pkg_map = Local_solver.Solver.Output.RoleMap
 

--- a/lib/opam_solve.mli
+++ b/lib/opam_solve.mli
@@ -17,6 +17,6 @@ val calculate :
     If [build_only] then no test dependencies are taken into account. If [ocaml_version]
     is provided, the solution will contain that concrete version of ocaml. *)
 
-val diagnostics_message : diagnostics -> [> `Msg of string ]
+val diagnostics_message : verbose:bool -> diagnostics -> [> `Msg of string ]
 
 val not_buildable_with_dune : diagnostics -> OpamPackage.Name.t list


### PR DESCRIPTION
By default 0install-solver will display `...` after the first 5 candidates. Now when `--verbose` is passed it displays everything.
