### PR TITLE
Allow marking certain packages as "installed via OPAM"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,10 @@
 - Show an error message when the solver can't find any version that satisfies
   the requested version constraint in the user's OPAM file (#215, #248,
   @Leonidas-from-XIV)
+- Allow packages to be marked as being provided by OPAM and not to be pulled by
+  opam-monorepo. To control this a new optional OPAM file field,
+  `x-opam-monorepo-opam-provided` is introduced. Its value is a list of package
+  names that are to be excluded from being pulled (#234, @Leonidas-from-XIV)
 
 ### Changed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,8 +8,8 @@
 - Show an error message when the solver can't find any version that satisfies
   the requested version constraint in the user's OPAM file (#215, #248,
   @Leonidas-from-XIV)
-- Allow packages to be marked as being provided by OPAM and not to be pulled by
-  opam-monorepo. To control this a new optional OPAM file field,
+- Allow packages to be marked as being provided by Opam and not to be pulled by
+  `opam-monorepo`. To control this a new optional Opam file field,
   `x-opam-monorepo-opam-provided` is introduced. Its value is a list of package
   names that are to be excluded from being pulled (#234, @Leonidas-from-XIV)
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,17 @@ opam-repository) thanks to the `pin-depends`.
 You can use that property to your advantage by allowing one to choose between a "monorepo" or
 regular opam workflow depending on the situation.
 
+You can also exclude packages from being included into the set of packages to
+be vendored by opam-monorepo. To do so you can specify an additional field in
+your OPAM file:
+
+```
+x-opam-monorepo-opam-provided: ["ocamlformat" "patdiff"]
+```
+
+This will exclude the packages from the list of packages opam-monorepo will
+pull, so they can be installed via `opam` manually.
+
 ### opam monorepo pull
 
 The `pull` command fetches the sources using the URLs in the lockfile. It benefits from the opam

--- a/README.md
+++ b/README.md
@@ -79,20 +79,20 @@ opam-repository) thanks to the `pin-depends`.
 You can use that property to your advantage by allowing one to choose between a "monorepo" or
 regular opam workflow depending on the situation.
 
-You can also exclude packages from being included into the set of packages to
-be vendored by opam-monorepo. To do so you can specify an additional field in
-your OPAM file:
+You can also exclude packages from the set of packages to
+be vendored by `opam-monorepo`. To do so you can specify an additional field in
+your Opam file:
 
 ```
 x-opam-monorepo-opam-provided: ["ocamlformat" "patdiff"]
 ```
 
-This will exclude the packages from the list of packages opam-monorepo will
+This will exclude the packages from the list of packages `opam-monorepo` will
 pull, so they can be installed via `opam` manually.
 
 ### opam monorepo pull
 
-The `pull` command fetches the sources using the URLs in the lockfile. It benefits from the opam
+The `pull` command fetches the sources using the URLs in the lockfile. It benefits from the Opam
 cache but its outcome does not depend on your opam configuration.
 
 ## Monorepo projects

--- a/cli/lock.ml
+++ b/cli/lock.ml
@@ -65,11 +65,11 @@ let opam_to_git_remote remote =
   | Some ("git", remote) -> remote
   | _ -> remote
 
-let compute_duniverse ~package_summaries =
+let compute_duniverse ~dependency_entries =
   let get_default_branch remote =
     Exec.git_default_branch ~remote:(opam_to_git_remote remote) ()
   in
-  Duniverse.from_package_summaries ~get_default_branch package_summaries
+  Duniverse.from_dependency_entries ~get_default_branch dependency_entries
 
 let resolve_ref deps =
   let resolve_ref ~repo ~ref =
@@ -425,16 +425,16 @@ let run (`Root root) (`Recurse_opam recurse) (`Build_only build_only)
   let* source_config =
     extract_source_config ~opam_monorepo_cwd:root ~opam_files target_packages
   in
-  let* package_summaries =
+  let* dependency_entries =
     calculate_opam ~source_config ~build_only ~allow_jbuilder ~ocaml_version
       ~local_opam_files:opam_files ~target_packages
   in
   Common.Logs.app (fun l -> l "Calculating exact pins for each of them.");
-  let* duniverse = compute_duniverse ~package_summaries >>= resolve_ref in
+  let* duniverse = compute_duniverse ~dependency_entries >>= resolve_ref in
   let target_depexts = target_depexts opam_files target_packages in
   let lockfile =
     Lockfile.create ~source_config ~root_packages:target_packages
-      ~package_summaries ~root_depexts:target_depexts ~duniverse ()
+      ~dependency_entries ~root_depexts:target_depexts ~duniverse ()
   in
   let* () =
     Lockfile.save ~opam_monorepo_cwd:root ~file:lockfile_path lockfile

--- a/cli/lock.ml
+++ b/cli/lock.ml
@@ -256,8 +256,24 @@ let extract_opam_env ~source_config global_state =
   | { global_vars = Some env; _ } -> env
   | { global_vars = None; _ } -> opam_env_from_global_state global_state
 
+let opam_provided_packages ~opam_monorepo_cwd local_packages target_packages =
+  let open Result.O in
+  OpamPackage.Name.Set.fold
+    (fun name acc ->
+      let* acc = acc in
+      match OpamPackage.Name.Map.find_opt name local_packages with
+      | Some (_version, opam) -> (
+          match Source_opam_config.get ~opam_monorepo_cwd opam with
+          | Ok config -> (
+              match config.opam_provided with
+              | None -> Ok acc
+              | Some provided -> Ok (OpamPackage.Name.Set.union provided acc))
+          | Error (`Msg msg) -> Error (`Msg msg))
+      | None -> Ok acc)
+    target_packages (Ok OpamPackage.Name.Set.empty)
+
 let calculate_opam ~source_config ~build_only ~allow_jbuilder ~local_opam_files
-    ~ocaml_version ~target_packages =
+    ~ocaml_version ~target_packages ~opam_provided =
   let open Result.O in
   OpamGlobalState.with_ `Lock_none (fun global_state ->
       let* pin_depends = get_pin_depends ~global_state local_opam_files in
@@ -274,7 +290,7 @@ let calculate_opam ~source_config ~build_only ~allow_jbuilder ~local_opam_files
           let opam_env = extract_opam_env ~source_config global_state in
           let solver = Opam_solve.explicit_repos_solver in
           Opam_solve.calculate ~build_only ~allow_jbuilder ~local_opam_files
-            ~target_packages ~pin_depends ?ocaml_version solver
+            ~target_packages ~opam_provided ~pin_depends ?ocaml_version solver
             (opam_env, local_repo_dirs)
           |> Result.map_error ~f:(interpret_solver_error ~repositories solver)
       | { repositories = None; _ } ->
@@ -284,7 +300,8 @@ let calculate_opam ~source_config ~build_only ~allow_jbuilder ~local_opam_files
                     (OpamSwitch.to_string switch_state.switch));
               let solver = Opam_solve.local_opam_config_solver in
               Opam_solve.calculate ~build_only ~allow_jbuilder ~local_opam_files
-                ~target_packages ~pin_depends ?ocaml_version solver switch_state
+                ~target_packages ~opam_provided ~pin_depends ?ocaml_version
+                solver switch_state
               |> Result.map_error ~f:(fun err ->
                      let repositories = current_repos ~switch_state in
                      interpret_solver_error ~repositories solver err)))
@@ -425,9 +442,12 @@ let run (`Root root) (`Recurse_opam recurse) (`Build_only build_only)
   let* source_config =
     extract_source_config ~opam_monorepo_cwd:root ~opam_files target_packages
   in
+  let* opam_provided =
+    opam_provided_packages ~opam_monorepo_cwd:root opam_files target_packages
+  in
   let* dependency_entries =
     calculate_opam ~source_config ~build_only ~allow_jbuilder ~ocaml_version
-      ~local_opam_files:opam_files ~target_packages
+      ~local_opam_files:opam_files ~target_packages ~opam_provided
   in
   Common.Logs.app (fun l -> l "Calculating exact pins for each of them.");
   let* duniverse = compute_duniverse ~dependency_entries >>= resolve_ref in

--- a/doc/index.mld
+++ b/doc/index.mld
@@ -9,3 +9,5 @@ Table of contents:
 - {{!page-faq}A FAQ} to answer common questions about [opam monorepo]
 - {{!page-concepts}A description of the concepts} behind [opam monorepo].
 - Some {{!page-workflows}common workflows} used in [opam monorepo] projects.
+- A {{!page-"opam-provided"} way to use [opam-monorepo] with non-[dune] dependencies}
+  for when it is not possible to use [dun]e

--- a/doc/opam-provided.mld
+++ b/doc/opam-provided.mld
@@ -1,15 +1,15 @@
 {1 [opam]-provided dependencies}
 
-This section documents a feature that is useful if not all dependencies can be
-installed via [opam-monorepo]. This workflow is not meant for regular use but
-only as a way to enable to use [opam-monorepo] in cases where it wouldn't be
+This section documents a feature that’s useful when some dependencies cannot be
+installed via [opam-monorepo]. This workflow isn’t meant for regular use but
+only as a way to use [opam-monorepo] in cases where it wouldn't be
 otherwise possible.
 
-We suggest minimizing its usage and prefer to use (and contribute) dune-ports
+We suggest minimizing its usage and prefer to use (and contribute) [dune-ports]
 from the [opam-overlays] repository. It's usage is safest with
-leaf-dependencies and those that do not have no dependency intersections with
-vendored packages. Due to possibly unexpected interactions this feature is only
-meant for advanced users and the solutions that it produces might be in flux.
+leaf-dependencies and those that don’t have dependency intersections with
+vendored packages. Due to possibly of unexpected interactions, this feature is only
+meant for advanced users, and the solutions it produces might be in flux.
 
 {2 Usecases}
 
@@ -18,43 +18,43 @@ be it due to your dependencies not building with [dune] or some tooling that
 should be just installed via [opam]. Such examples include:
 
 {ul
-{- Packages not building with dune}
+{- Packages not building with Dune}
 {- Packages that should not be vendored for legal reasons}
 {- Packages that just provide helper binaries like [utop], [ocamlformat]}
 }
 
-These users can opt-in into having some of their dependencies provided by
-[opam] instead of [opam-monorepo] pulling them into the duniverse.
+These users can opt-in to having some of their dependencies provided by
+[opam] instead of [opam-monorepo] pulling them into the [duniverse].
 
 {2 Initial setup}
 
-With the default configuration [opam-monorepo] runs in full-duniverse mode,
-that is requiring all the dependencies of your [opam] files to be able to be
-built as part of the duniverse.
+With the default configuration, [opam-monorepo] runs in full-[duniverse] mode,
+i.e., requiring all the dependencies of your [opam] files to be able to be
+built as part of the [duniverse].
 
 As such it is only recommended that packages are installed via [opam] for which
-there is no way to install them via [dune], e.g. by using the
+there is no way to install them via [dune], e.g., by using the
 {{:https://github.com/dune-universe/opam-overlays}opam-overlays} repository
-with dune ports.
+with Dune ports.
 
-To let [opam-monorepo] know a package is to be installed via [opam] it needs to
-be marked as such in the opam file. For this the
-[x-opam-monorepo-opam-provided] field is used, which takes a single or a list
-of packages to be installed via [opam] instead of pulled into the duniverse.
+To let [opam-monorepo] know a package is to be installed via [opam], it needs to
+be marked as such in the Opam file. For this, we use the
+[x-opam-monorepo-opam-provided] field, which takes a single or a list
+of packages to be installed via [opam] instead of pulled into the [duniverse].
 
-To configure [opam-monorepo] to avoid pulling in package [foo] specify it in
-the list of packages that are to be provided by [opam]:
+To configure [opam-monorepo] to avoid pulling in package [foo], specify it in
+the list of packages provided by Opam:
 
 {[
 x-opam-monorepo-opam-provided: ["foo"]
 ]}
 
-This can either be specified directly in the [opam] file or, if you use [dune]
-to generate [opam] files, in the [.template] file. In such case make sure to
-re-generate the [opam] file.
+This can either be specified directly in the Opam file or, if you use Dune
+to generate Opam files, in the [.template] file. In such case, make sure to
+regenerate the Opam file.
 
-As a shortcut syntax if there is only one package it is possible to leave the
-list out and just specify the package itself:
+As a shortcut syntax, if there’s only one package, it’s possible to leave out the
+list and just specify the package itself:
 
 {[
 x-opam-monorepo-opam-provided: "foo"
@@ -62,15 +62,14 @@ x-opam-monorepo-opam-provided: "foo"
 
 {2 Usage}
 
-After you configured your [opam] file, you have to {e lock} the environment.
+After you configured your Opam file, you have to {e lock} the environment.
 
 {[
 $ opam monorepo lock
 ]}
 
-After this succeeds, you will have a [.opam.locked] file, which contains all
-the dependencies (including transitive dependencies) of your project. The ones
-that [opam-monorepo] will pull into the duniverse are marked as [vendor].
+After this succeeds, you will have an [.opam.locked] file, which contains all your project’s dependencies (including transitive dependencies). The ones
+that [opam-monorepo] will pull into the [duniverse] are marked as [vendor].
 
 {[
 $ opam install --ignore-pin-depends --deps-only ./ --locked
@@ -80,20 +79,17 @@ $ opam-monorepo pull
 {2 How it works}
 
 In addition to calculating the dependencies of the packages that will be
-included in the duniverse, [opam-monorepo] calculates the dependencies of the
+included in the [duniverse], [opam-monorepo] calculates the dependencies of the
 packages to be installed via [opam]. [opam-monorepo] then writes a lockfile
-that sets a variable on all dependencies it will pull, whereas [opam]-provided
-dependencies don't have variables set. In [opam] unset variables are false,
-thus [opam] will ignore the packages that [opam-monorepo] will pull.
+that sets a variable on all the dependencies it will pull, whereas [opam]-provided
+dependencies don't have variables set. In Opam, unset variables are false; thus Opam will ignore the packages that [opam-monorepo] will pull.
 
-The [opam]-provided subset of dependencies is then {e excluded} from the
-packages from the duniverse.
+The [opam]-provided subset of dependencies is then {e excluded} from the [duniverse] packages.
 
 {3 Resolution of dependency overlaps}
 
-There are cases where a dependency package appears multiple times in the
-dependency tree of a project. It can happen that a package is part of packages
-to be included in the duniverse as well as packages installed by [opam].
+There are cases where a dependency package appears multiple times in the project’s dependency tree. It’s possible that a package is part of the packages
+to be included in the [duniverse], as well as packages installed by [opam].
 
 In such cases there are two possibilities:
 
@@ -104,6 +100,6 @@ In such cases there are two possibilities:
 
 Both these approaches have advantages and disadvantages. [opam-monorepo]
 currently chooses #2 to maximize the amount of packages that are vendored, thus
-increasing the size of the reproducible set. Yet this does not mean that two
-different versions of the package can be installed - the set of packages in
-opam and the duniverse must be co-installable!
+increasing the size of the reproducible set. Yet this doesn’t mean that two
+different versions of the package can be installed. The set of packages in
+Opam and the [duniverse] must be co-installable!

--- a/doc/opam-provided.mld
+++ b/doc/opam-provided.mld
@@ -1,0 +1,93 @@
+{1 [opam]-provided dependencies}
+
+This section documents a feature that is useful if not all dependencies can be
+installed via [opam-monorepo]. This workflow is not meant for regular use but
+only as a way to enable to use [opam-monorepo] in cases where it wouldn't be
+otherwise possible.
+
+{2 Usecases}
+
+Sometimes it is not possible to put all your dependencies into the [duniverse],
+be it due to  your dependencies not building with [dune] or some tooling that
+should be just installed via [opam]. Such examples include:
+
+{ul
+{- TODO}
+}
+
+These users can opt-in into having some of their dependencies provided by
+[opam] instead of [opam-monorepo] pulling them into the duniverse.
+
+{2 Initial setup}
+
+With the default configuration [opam-monorepo] runs in full-duniverse mode,
+that is requiring all the dependencies of your [opam] files to be able to be
+built as part of the duniverse.
+
+As such it is only recommended that packages are installed via [opam] for which
+there is no way to install them via [dune], e.g. by using the
+{{:https://github.com/dune-universe/opam-overlays}opam-overlays} repository
+with dune ports.
+
+To let [opam-monorepo] know a package is to be installed via [opam] it needs to
+be marked as such in the opam file. For this the
+[x-opam-monorepo-opam-provided] field is used, which takes a single or a list
+of packages to be installed via [opam] instead of pulled into the duniverse.
+
+To configure [opam-monorepo] to avoid pulling in package [foo] into the
+duniverse use this syntax in your [opam] file:
+
+{[
+x-opam-monorepo-opam-provided: [foo]
+]}
+
+This can either be specified directly in the [opam] file or, if you use [dune]
+to generate [opam] files, in the [.template] file. In such case make sure to
+re-generate the [opam] file.
+
+{2 Usage}
+
+After you configured your [opam] file, you have to {e lock} the environment.
+
+{[
+$ opam monorepo lock
+]}
+
+After this succeeds, you will have a [.opam.locked] file, which contains all
+the dependencies (including transitive dependencies) of your project. The ones
+that [opam-monorepo] will pull into the duniverse are marked as [vendor].
+
+{[
+$ opam install --ignore-pin-depends --deps-only ./ --locked
+$ opam-monorepo pull
+]}
+
+{2 How it works}
+
+In addition to calculating the dependencies of the packages that will be
+included in the duniverse, [opam-monorepo] calculates the dependencies of the
+packages to be installed via [opam]. [opam-monorepo] then writes a lockfile
+that sets a variable on all dependencies it will pull, whereas [opam]-provided
+dependencies don't have variables set. In [opam] unset variables are false,
+thus [opam] will ignore the packages that [opam-monorepo] will pull.
+
+The [opam]-provided subset of dependencies is then {e excluded} from the
+packages from the duniverse.
+
+{3 Resolution of dependency overlaps}
+
+There are cases where a dependency package appears multiple times in the
+dependency tree of a project. It can happen that a package is part of packages
+to be included in the duniverse as well as packages installed by [opam].
+
+In such cases there are two possibilities:
+
+{ol
+{- Install the package in [opam], exclude it from duniverse}
+{- Install the package in [opam], include a duplicate in the duniverse}
+}
+
+Both these approaches have advantages and disadvantages. For simplicity
+[opam-monorepo] currently choses #1, since the dependent package needs to be
+installed in [opam] in any case and packages built in the duniverse can access
+[opam]-provided packages as well.

--- a/doc/opam-provided.mld
+++ b/doc/opam-provided.mld
@@ -8,7 +8,7 @@ otherwise possible.
 {2 Usecases}
 
 Sometimes it is not possible to put all your dependencies into the [duniverse],
-be it due to  your dependencies not building with [dune] or some tooling that
+be it due to your dependencies not building with [dune] or some tooling that
 should be just installed via [opam]. Such examples include:
 
 {ul
@@ -96,7 +96,8 @@ In such cases there are two possibilities:
 {- Install the package in [opam], include a duplicate in the duniverse}
 }
 
-Both these approaches have advantages and disadvantages. For simplicity
-[opam-monorepo] currently choses #1, since the dependent package needs to be
-installed in [opam] in any case and packages built in the duniverse can access
-[opam]-provided packages as well.
+Both these approaches have advantages and disadvantages. [opam-monorepo]
+currently chooses #2 to maximize the amount of packages that are vendored, thus
+increasing the size of the reproducible set. Yet this does not mean that two
+different versions of the package can be installed - the set of packages in
+opam and the duniverse must be co-installable!

--- a/doc/opam-provided.mld
+++ b/doc/opam-provided.mld
@@ -20,7 +20,6 @@ should be just installed via [opam]. Such examples include:
 {ul
 {- Packages not building with Dune}
 {- Packages that should not be vendored for legal reasons}
-{- Packages that just provide helper binaries like [utop], [ocamlformat]}
 }
 
 These users can opt-in to having some of their dependencies provided by [opam]
@@ -33,7 +32,7 @@ i.e., requiring all the dependencies of your [opam] files to be able to be
 built as part of the [duniverse].
 
 As such it is only recommended that packages are installed via [opam] for which
-there is no way to install them via [dune], e.g., by using the
+there is no way to build them with [dune], e.g., by using the
 {{:https://github.com/dune-universe/opam-overlays}opam-overlays} repository
 with Dune ports.
 

--- a/doc/opam-provided.mld
+++ b/doc/opam-provided.mld
@@ -5,6 +5,12 @@ installed via [opam-monorepo]. This workflow is not meant for regular use but
 only as a way to enable to use [opam-monorepo] in cases where it wouldn't be
 otherwise possible.
 
+We suggest minimizing its usage and prefer to use (and contribute) dune-ports
+from the [opam-overlays] repository. It's usage is safest with
+leaf-dependencies and those that do not have no dependency intersections with
+vendored packages. Due to possibly unexpected interactions this feature is only
+meant for advanced users and the solutions that it produces might be in flux.
+
 {2 Usecases}
 
 Sometimes it is not possible to put all your dependencies into the [duniverse],

--- a/doc/opam-provided.mld
+++ b/doc/opam-provided.mld
@@ -2,14 +2,14 @@
 
 This section documents a feature that’s useful when some dependencies cannot be
 installed via [opam-monorepo]. This workflow isn’t meant for regular use but
-only as a way to use [opam-monorepo] in cases where it wouldn't be
-otherwise possible.
+only as a way to use [opam-monorepo] in cases where it wouldn't be otherwise
+possible.
 
 We suggest minimizing its usage and prefer to use (and contribute) [dune-ports]
 from the [opam-overlays] repository. It's usage is safest with
 leaf-dependencies and those that don’t have dependency intersections with
-vendored packages. Due to possibly of unexpected interactions, this feature is only
-meant for advanced users, and the solutions it produces might be in flux.
+vendored packages. Due to possibly of unexpected interactions, this feature is
+only meant for advanced users, and the solutions it produces might be in flux.
 
 {2 Usecases}
 
@@ -23,8 +23,8 @@ should be just installed via [opam]. Such examples include:
 {- Packages that just provide helper binaries like [utop], [ocamlformat]}
 }
 
-These users can opt-in to having some of their dependencies provided by
-[opam] instead of [opam-monorepo] pulling them into the [duniverse].
+These users can opt-in to having some of their dependencies provided by [opam]
+instead of [opam-monorepo] pulling them into the [duniverse].
 
 {2 Initial setup}
 
@@ -37,26 +37,34 @@ there is no way to install them via [dune], e.g., by using the
 {{:https://github.com/dune-universe/opam-overlays}opam-overlays} repository
 with Dune ports.
 
-To let [opam-monorepo] know a package is to be installed via [opam], it needs to
-be marked as such in the Opam file. For this, we use the
-[x-opam-monorepo-opam-provided] field, which takes a single or a list
-of packages to be installed via [opam] instead of pulled into the [duniverse].
+To let [opam-monorepo] know a package is to be installed via [opam], it needs
+to be marked as such in the Opam file. For this, it needs to be added as normal
+in the [depends] field, as well in addition into the new
+[x-opam-monorepo-opam-provided] field. This field takes a single package or a
+list of packages to be installed via [opam] instead of being pulled into the
+[duniverse].
 
 To configure [opam-monorepo] to avoid pulling in package [foo], specify it in
 the list of packages provided by Opam:
 
 {[
+depends: [
+  "foo"
+]
 x-opam-monorepo-opam-provided: ["foo"]
 ]}
 
-This can either be specified directly in the Opam file or, if you use Dune
-to generate Opam files, in the [.template] file. In such case, make sure to
+This can either be specified directly in the Opam file or, if you use Dune to
+generate Opam files, in the [.template] file. In such case, make sure to
 regenerate the Opam file.
 
-As a shortcut syntax, if there’s only one package, it’s possible to leave out the
-list and just specify the package itself:
+As a shortcut syntax, if there’s only one package, it’s possible to leave out
+the list and just specify the package itself:
 
 {[
+depends: [
+  "foo"
+]
 x-opam-monorepo-opam-provided: "foo"
 ]}
 
@@ -68,8 +76,9 @@ After you configured your Opam file, you have to {e lock} the environment.
 $ opam monorepo lock
 ]}
 
-After this succeeds, you will have an [.opam.locked] file, which contains all your project’s dependencies (including transitive dependencies). The ones
-that [opam-monorepo] will pull into the [duniverse] are marked as [vendor].
+After this succeeds, you will have an [.opam.locked] file, which contains all
+your project’s dependencies (including transitive dependencies). The ones that
+[opam-monorepo] will pull into the [duniverse] are marked as [vendor].
 
 {[
 $ opam install --ignore-pin-depends --deps-only ./ --locked
@@ -81,14 +90,17 @@ $ opam-monorepo pull
 In addition to calculating the dependencies of the packages that will be
 included in the [duniverse], [opam-monorepo] calculates the dependencies of the
 packages to be installed via [opam]. [opam-monorepo] then writes a lockfile
-that sets a variable on all the dependencies it will pull, whereas [opam]-provided
-dependencies don't have variables set. In Opam, unset variables are false; thus Opam will ignore the packages that [opam-monorepo] will pull.
+that sets a variable on all the dependencies it will pull, whereas
+[opam]-provided dependencies don't have variables set. In Opam, unset variables
+are false; thus Opam will ignore the packages that [opam-monorepo] will pull.
 
-The [opam]-provided subset of dependencies is then {e excluded} from the [duniverse] packages.
+The [opam]-provided subset of dependencies is then {e excluded} from the
+[duniverse] packages.
 
 {3 Resolution of dependency overlaps}
 
-There are cases where a dependency package appears multiple times in the project’s dependency tree. It’s possible that a package is part of the packages
+There are cases where a dependency package appears multiple times in the
+project’s dependency tree. It’s possible that a package is part of the packages
 to be included in the [duniverse], as well as packages installed by [opam].
 
 In such cases there are two possibilities:
@@ -101,5 +113,5 @@ In such cases there are two possibilities:
 Both these approaches have advantages and disadvantages. [opam-monorepo]
 currently chooses #2 to maximize the amount of packages that are vendored, thus
 increasing the size of the reproducible set. Yet this doesn’t mean that two
-different versions of the package can be installed. The set of packages in
-Opam and the [duniverse] must be co-installable!
+different versions of the package can be installed. The set of packages in Opam
+and the [duniverse] must be co-installable!

--- a/doc/opam-provided.mld
+++ b/doc/opam-provided.mld
@@ -12,7 +12,9 @@ be it due to  your dependencies not building with [dune] or some tooling that
 should be just installed via [opam]. Such examples include:
 
 {ul
-{- TODO}
+{- Packages not building with dune}
+{- Packages that should not be vendored for legal reasons}
+{- Packages that just provide helper binaries like [utop], [ocamlformat]}
 }
 
 These users can opt-in into having some of their dependencies provided by
@@ -34,16 +36,23 @@ be marked as such in the opam file. For this the
 [x-opam-monorepo-opam-provided] field is used, which takes a single or a list
 of packages to be installed via [opam] instead of pulled into the duniverse.
 
-To configure [opam-monorepo] to avoid pulling in package [foo] into the
-duniverse use this syntax in your [opam] file:
+To configure [opam-monorepo] to avoid pulling in package [foo] specify it in
+the list of packages that are to be provided by [opam]:
 
 {[
-x-opam-monorepo-opam-provided: [foo]
+x-opam-monorepo-opam-provided: ["foo"]
 ]}
 
 This can either be specified directly in the [opam] file or, if you use [dune]
 to generate [opam] files, in the [.template] file. In such case make sure to
 re-generate the [opam] file.
+
+As a shortcut syntax if there is only one package it is possible to leave the
+list out and just specify the package itself:
+
+{[
+x-opam-monorepo-opam-provided: "foo"
+]}
 
 {2 Usage}
 

--- a/lib/duniverse.ml
+++ b/lib/duniverse.ml
@@ -86,7 +86,9 @@ module Repo = struct
       in
       match ps with
       | _ when is_base_package ps -> Ok None
-      | { url_src = None; _ } | { dev_repo = None; _ } -> Ok None
+      | { url_src = None; _ } | { dev_repo = None; _ } | { vendored = false; _ }
+        ->
+          Ok None
       | { url_src = Some url_src; package; dev_repo = Some dev_repo; hashes; _ }
         ->
           let* url = url url_src in

--- a/lib/duniverse.ml
+++ b/lib/duniverse.ml
@@ -86,9 +86,7 @@ module Repo = struct
       in
       match ps with
       | _ when is_base_package ps -> Ok None
-      | { url_src = None; _ } | { dev_repo = None; _ } | { vendored = false; _ }
-        ->
-          Ok None
+      | { url_src = None; _ } | { dev_repo = None; _ } -> Ok None
       | { url_src = Some url_src; package; dev_repo = Some dev_repo; hashes; _ }
         ->
           let* url = url url_src in
@@ -207,8 +205,14 @@ let dev_repo_map_from_packages packages =
         | Some pkgs -> Some (pkg :: pkgs)
         | None -> Some [ pkg ]))
 
-let from_package_summaries ~get_default_branch summaries =
+let from_dependency_entries ~get_default_branch dependencies =
   let open Result.O in
+  let summaries =
+    List.map
+      ~f:(fun Opam.Dependency_entry.{ package_summary; vendored = _ } ->
+        package_summary)
+      dependencies
+  in
   let results =
     List.map
       ~f:(Repo.Package.from_package_summary ~get_default_branch)

--- a/lib/duniverse.mli
+++ b/lib/duniverse.mli
@@ -63,9 +63,9 @@ type t = resolved Repo.t list
 
 val equal : t -> t -> bool
 
-val from_package_summaries :
+val from_dependency_entries :
   get_default_branch:(string -> (string, Rresult.R.msg) result) ->
-  Opam.Package_summary.t list ->
+  Opam.Dependency_entry.t list ->
   (unresolved Repo.t list, [ `Msg of string ]) result
 (** Build opamverse and duniverse from a list of [Types.Opam.entry] values.
     It filters out virtual packages and packages with unknown dev-repo.  *)

--- a/lib/lockfile.ml
+++ b/lib/lockfile.ml
@@ -95,6 +95,7 @@ module Depends = struct
         let vendored =
           (not @@ Opam.Package_summary.is_base_package summary)
           && (not @@ Opam.Package_summary.is_virtual summary)
+          && summary.vendored
         in
         { vendored; package = summary.package })
 

--- a/lib/lockfile.ml
+++ b/lib/lockfile.ml
@@ -90,14 +90,15 @@ module Depends = struct
 
   type t = dependency list
 
-  let from_package_summaries l =
-    List.map l ~f:(fun summary ->
+  let from_dependency_entries dependency_entries =
+    List.map dependency_entries
+      ~f:(fun Opam.Dependency_entry.{ vendored; package_summary } ->
         let vendored =
-          (not @@ Opam.Package_summary.is_base_package summary)
-          && (not @@ Opam.Package_summary.is_virtual summary)
-          && summary.vendored
+          (not @@ Opam.Package_summary.is_base_package package_summary)
+          && (not @@ Opam.Package_summary.is_virtual package_summary)
+          && vendored
         in
-        { vendored; package = summary.package })
+        { vendored; package = package_summary.package })
 
   let variable_equal a b =
     String.equal (OpamVariable.to_string a) (OpamVariable.to_string b)
@@ -241,7 +242,13 @@ module Depexts = struct
     let c = OpamSysPkg.Set.compare pkg_set pkg_set' in
     if c = 0 then compare filter filter' else c
 
-  let all ~root_depexts ~package_summaries =
+  let all ~root_depexts ~dependency_entries =
+    let package_summaries =
+      List.map
+        ~f:(fun Opam.Dependency_entry.{ package_summary; vendored = _ } ->
+          package_summary)
+        dependency_entries
+    in
     let transitive_depexts =
       List.map
         ~f:(fun { Opam.Package_summary.depexts; _ } -> depexts)
@@ -263,13 +270,13 @@ type t = {
 
 let depexts t = t.depexts
 
-let create ~source_config ~root_packages ~package_summaries ~root_depexts
+let create ~source_config ~root_packages ~dependency_entries ~root_depexts
     ~duniverse () =
   let version = Version.current in
-  let depends = Depends.from_package_summaries package_summaries in
+  let depends = Depends.from_dependency_entries dependency_entries in
   let pin_depends = Pin_depends.from_duniverse duniverse in
   let duniverse_dirs = Duniverse_dirs.from_duniverse duniverse in
-  let depexts = Depexts.all ~root_depexts ~package_summaries in
+  let depexts = Depexts.all ~root_depexts ~dependency_entries in
   {
     version;
     root_packages;

--- a/lib/lockfile.mli
+++ b/lib/lockfile.mli
@@ -3,7 +3,7 @@ type t
 val create :
   source_config:Source_opam_config.t ->
   root_packages:OpamPackage.Name.Set.t ->
-  package_summaries:Opam.Package_summary.t list ->
+  dependency_entries:Opam.Dependency_entry.t list ->
   root_depexts:(OpamSysPkg.Set.t * OpamTypes.filter) list list ->
   duniverse:Duniverse.t ->
   unit ->

--- a/lib/opam.ml
+++ b/lib/opam.ml
@@ -159,29 +159,27 @@ module Package_summary = struct
     hashes : OpamHash.t list;
     dev_repo : string option;
     depexts : (OpamSysPkg.Set.t * OpamTypes.filter) list;
-    vendored : bool;
   }
 
-  let equal { package; url_src; hashes; dev_repo; depexts; vendored } t' =
+  let equal { package; url_src; hashes; dev_repo; depexts } t' =
     OpamPackage.equal package t'.package
     && Option.equal Url.equal url_src t'.url_src
     && List.equal Hash.equal hashes t'.hashes
     && Option.equal String.equal dev_repo t'.dev_repo
     && Depexts.equal depexts t'.depexts
-    && Bool.equal vendored t'.vendored
 
-  let pp fmt { package; url_src; hashes; dev_repo; depexts; vendored } =
+  let pp fmt { package; url_src; hashes; dev_repo; depexts } =
     let open Pp_combinators.Ocaml in
     Format.fprintf fmt
       "@[<hov 2>{ name = %a;@ version = %a;@ url_src = %a;@ hashes = %a;@ \
-       dev_repo = %a;@ depexts = %a; @vendored = %a }@]"
+       dev_repo = %a;@ depexts = %a }@]"
       Pp.package_name package.name Pp.version package.version
       (option ~brackets:true Url.pp)
       url_src (list Hash.pp) hashes
       (option ~brackets:true string)
-      dev_repo Depexts.pp depexts Pp_combinators.Ocaml.bool vendored
+      dev_repo Depexts.pp depexts
 
-  let from_opam ?(vendored = true) package opam_file =
+  let from_opam package opam_file =
     let url_field = OpamFile.OPAM.url opam_file in
     let url_src = Option.map ~f:Url.from_opam_field url_field in
     let hashes =
@@ -191,7 +189,7 @@ module Package_summary = struct
       Option.map ~f:OpamUrl.to_string (OpamFile.OPAM.dev_repo opam_file)
     in
     let depexts = OpamFile.OPAM.depexts opam_file in
-    { package; url_src; hashes; dev_repo; depexts; vendored }
+    { package; url_src; hashes; dev_repo; depexts }
 
   let is_virtual = function
     | { url_src = None; _ } -> true
@@ -203,6 +201,10 @@ module Package_summary = struct
       when OpamPackage.Name.Set.mem package.name Config.base_packages ->
         true
     | _ -> false
+end
+
+module Dependency_entry = struct
+  type t = { package_summary : Package_summary.t; vendored : bool }
 end
 
 let local_package_version opam_file ~explicit_version =

--- a/lib/opam.ml
+++ b/lib/opam.ml
@@ -127,7 +127,12 @@ module Depexts = struct
 end
 
 module Pp = struct
-  let package = Fmt.using OpamPackage.to_string Fmt.string
+  module Package : Pp_combinators.Opam.Printable with type t = OpamPackage.t =
+  struct
+    type t = OpamPackage.t
+
+    let pp = Fmt.using OpamPackage.to_string Fmt.string
+  end
 
   module Package_name :
     Pp_combinators.Opam.Printable with type t = OpamPackage.Name.t = struct
@@ -138,6 +143,9 @@ module Pp = struct
 
   module Package_name_set =
     Pp_combinators.Opam.Make_Set (OpamPackage.Name.Set) (Package_name)
+  module Package_set = Pp_combinators.Opam.Make_Set (OpamPackage.Set) (Package)
+
+  let package = Package.pp
 
   let package_name = Package_name.pp
 

--- a/lib/opam.mli
+++ b/lib/opam.mli
@@ -23,19 +23,22 @@ module Package_summary : sig
     hashes : OpamHash.t list;
     dev_repo : string option;
     depexts : (OpamSysPkg.Set.t * OpamTypes.filter) list;
-    vendored : bool;
   }
 
   val equal : t -> t -> bool
 
   val pp : t Fmt.t
 
-  val from_opam : ?vendored:bool -> OpamPackage.t -> OpamFile.OPAM.t -> t
+  val from_opam : OpamPackage.t -> OpamFile.OPAM.t -> t
 
   val is_virtual : t -> bool
   (** A package is considered virtual if it has no url.src or no dev-repo. *)
 
   val is_base_package : t -> bool
+end
+
+module Dependency_entry : sig
+  type t = { package_summary : Package_summary.t; vendored : bool }
 end
 
 module Hash : sig

--- a/lib/opam.mli
+++ b/lib/opam.mli
@@ -60,6 +60,10 @@ module Pp : sig
     val pp : ?sep:unit Fmt.t -> OpamPackage.Name.Set.t Fmt.t
   end
 
+  module Package_set : sig
+    val pp : ?sep:unit Fmt.t -> OpamPackage.Set.t Fmt.t
+  end
+
   val package_name : OpamPackage.Name.t Fmt.t
 
   val version : OpamPackage.Version.t Fmt.t

--- a/lib/opam.mli
+++ b/lib/opam.mli
@@ -23,13 +23,14 @@ module Package_summary : sig
     hashes : OpamHash.t list;
     dev_repo : string option;
     depexts : (OpamSysPkg.Set.t * OpamTypes.filter) list;
+    vendored : bool;
   }
 
   val equal : t -> t -> bool
 
   val pp : t Fmt.t
 
-  val from_opam : pkg:OpamPackage.t -> OpamFile.OPAM.t -> t
+  val from_opam : ?vendored:bool -> OpamPackage.t -> OpamFile.OPAM.t -> t
 
   val is_virtual : t -> bool
   (** A package is considered virtual if it has no url.src or no dev-repo. *)
@@ -45,6 +46,16 @@ module Pp : sig
   val package : OpamPackage.t Fmt.t
 
   val raw_package : OpamPackage.t Fmt.t
+
+  module Package_name : sig
+    type t = OpamPackage.Name.t
+
+    val pp : t Fmt.t
+  end
+
+  module Package_name_set : sig
+    val pp : ?sep:unit Fmt.t -> OpamPackage.Name.Set.t Fmt.t
+  end
 
   val package_name : OpamPackage.Name.t Fmt.t
 

--- a/lib/opam_solve.ml
+++ b/lib/opam_solve.ml
@@ -296,7 +296,10 @@ module Make_solver (Context : OPAM_MONOREPO_CONTEXT) :
   let calculate_raw_with_opam_provided ~local_packages ~opam_provided ~request
       context vendored_packages =
     match Solver.solve context request with
-    | Error e -> Error (`Diagnostics e)
+    | Error e ->
+        Logs.err (fun l ->
+            l "Solving opam-provided dependencies could not find a solution");
+        Error (`Diagnostics e)
     | Ok selections ->
         let vendored_package_names =
           vendored_packages |> OpamPackage.Set.elements

--- a/lib/opam_solve.ml
+++ b/lib/opam_solve.ml
@@ -138,15 +138,19 @@ module Opam_monorepo_context (Base_context : BASE_CONTEXT) :
       versions
 
   let remove_opam_provided ~opam_provided versions =
-    versions
-    |> List.map ~f:(fun (version, result) ->
-           match result with
-           | Error _ as e -> (version, e)
-           | Ok opam_file ->
-               let opam_file =
-                 remove_opam_provided_from_dependencies opam_provided opam_file
-               in
-               (version, Ok opam_file))
+    match OpamPackage.Name.Set.is_empty opam_provided with
+    | true -> versions
+    | false ->
+        versions
+        |> List.map ~f:(fun (version, result) ->
+               match result with
+               | Error _ as e -> (version, e)
+               | Ok opam_file ->
+                   let opam_file =
+                     remove_opam_provided_from_dependencies opam_provided
+                       opam_file
+                   in
+                   (version, Ok opam_file))
 
   let candidates
       {

--- a/lib/opam_solve.ml
+++ b/lib/opam_solve.ml
@@ -425,8 +425,6 @@ module Make_solver (Context : OPAM_MONOREPO_CONTEXT) :
               msg);
         assert false
 
-  (* TODO catch exceptions and turn to error *)
-
   let calculate ~build_only ~allow_jbuilder ~local_opam_files:local_packages
       ~target_packages ~pin_depends ?ocaml_version input =
     let open Result.O in
@@ -438,8 +436,8 @@ module Make_solver (Context : OPAM_MONOREPO_CONTEXT) :
       match opam_provided_packages local_packages target_packages with
       | Ok opam_provided -> opam_provided
       | Error msg ->
-          Fmt.epr
-            "TODO: Error parsing x-opam-monorepo-provided: %s, ignoring.\n" msg;
+          Logs.warn (fun l ->
+              l "Error parsing x-opam-monorepo-provided: %s, ignoring.\n" msg);
           OpamPackage.Name.Set.empty
     in
 

--- a/lib/opam_solve.ml
+++ b/lib/opam_solve.ml
@@ -87,19 +87,11 @@ module Opam_monorepo_context (Base_context : BASE_CONTEXT) :
       Opam.depends_on_dune ~allow_jbuilder depends
       || Opam.depends_on_dune ~allow_jbuilder depopts
     in
-    let uses_dune =
-      match require_dune with
-      | false -> true
-      | true -> (
-          (* if it is exempt, we assume it uses dune *)
-          match OpamPackage.Name.Set.mem name exempt_dune_for with
-          | true -> true
-          | false -> uses_dune)
-    in
+    let exempt_from_dune = OpamPackage.Name.Set.mem name exempt_dune_for in
     let summary = Opam.Package_summary.from_opam pkg opam_file in
     Opam.Package_summary.is_base_package summary
     || Opam.Package_summary.is_virtual summary
-    || uses_dune
+    || exempt_from_dune || (not require_dune) || uses_dune
 
   let filter_candidates ~allow_jbuilder ~require_dune ~exempt_dune_for ~name
       versions =

--- a/lib/opam_solve.ml
+++ b/lib/opam_solve.ml
@@ -243,7 +243,7 @@ module type OPAM_MONOREPO_SOLVER = sig
     pin_depends:(OpamTypes.version * OpamFile.OPAM.t) OpamPackage.Name.Map.t ->
     ?ocaml_version:string ->
     input ->
-    ( Opam.Package_summary.t list,
+    ( Opam.Dependency_entry.t list,
       [> `Diagnostics of diagnostics | `Msg of string ] )
     result
 
@@ -511,7 +511,11 @@ module Make_solver (Context : OPAM_MONOREPO_CONTEXT) :
 
   let get_opam_info ~context { package; vendored } =
     match Context.opam_file context package with
-    | Ok opam_file -> Opam.Package_summary.from_opam ~vendored package opam_file
+    | Ok opam_file ->
+        let package_summary =
+          Opam.Package_summary.from_opam package opam_file
+        in
+        Opam.Dependency_entry.{ package_summary; vendored }
     | Error (`Msg msg) ->
         (* If we're calling this function on a package, it means it has been
            returned as part of the solver solution and therefore should correspond
@@ -666,7 +670,7 @@ let calculate :
     ?ocaml_version:string ->
     (context, diagnostics) t ->
     context ->
-    ( Opam.Package_summary.t list,
+    ( Opam.Dependency_entry.t list,
       [> `Diagnostics of diagnostics | `Msg of string ] )
     result =
  fun ~build_only ~allow_jbuilder ~local_opam_files ~target_packages ~pin_depends

--- a/lib/opam_solve.mli
+++ b/lib/opam_solve.mli
@@ -30,7 +30,7 @@ val calculate :
   ( Opam.Dependency_entry.t list,
     [> `Diagnostics of 'diagnostics | `Msg of string ] )
   result
-(** Calculates a solution for the provided local packages and their opam files
+(** Calculates a solution for the provided local packages and their Opam files
     containing their regular and test dependencies using the provided opam switch
     state. Uses [Opam_0install].
     If [build_only] then no test dependencies are taken into account. If [ocaml_version]

--- a/lib/opam_solve.mli
+++ b/lib/opam_solve.mli
@@ -26,7 +26,7 @@ val calculate :
   ?ocaml_version:string ->
   ('context, 'diagnostics) t ->
   'context ->
-  ( Opam.Package_summary.t list,
+  ( Opam.Dependency_entry.t list,
     [> `Diagnostics of 'diagnostics | `Msg of string ] )
   result
 (** Calculates a solution for the provided local packages and their opam files

--- a/lib/opam_solve.mli
+++ b/lib/opam_solve.mli
@@ -22,6 +22,7 @@ val calculate :
   allow_jbuilder:bool ->
   local_opam_files:(OpamTypes.version * OpamFile.OPAM.t) OpamPackage.Name.Map.t ->
   target_packages:OpamPackage.Name.Set.t ->
+  opam_provided:OpamPackage.Name.Set.t ->
   pin_depends:(OpamTypes.version * OpamFile.OPAM.t) OpamPackage.Name.Map.t ->
   ?ocaml_version:string ->
   ('context, 'diagnostics) t ->

--- a/lib/pin_depends.ml
+++ b/lib/pin_depends.ml
@@ -16,14 +16,10 @@ let sort_uniq pin_depends =
     | Some t' when equal t t' -> Ok acc
     | Some (pkg', url') ->
         Rresult.R.error_msgf
-          "Package %s is pinned to different versions/url:\n\
-          \  - %s: %s\n\
-          \  - %s: %s"
-          (OpamPackage.Name.to_string name)
-          (OpamPackage.to_string pkg)
-          (OpamUrl.to_string url)
-          (OpamPackage.to_string pkg')
-          (OpamUrl.to_string url')
+          "Package %a is pinned to different versions/url:\n\
+          \  - %a: %a\n\
+          \  - %a: %a" Opam.Pp.package_name name Opam.Pp.package pkg Opam.Pp.url
+          url Opam.Pp.package pkg' Opam.Pp.url url'
   in
   let+ map =
     Result.List.fold_left ~init:OpamPackage.Name.Map.empty ~f:add pin_depends

--- a/lib/pp_combinators.ml
+++ b/lib/pp_combinators.ml
@@ -20,3 +20,17 @@ module Ocaml = struct
   let pair pp_a pp_b fmt (a, b) =
     Format.fprintf fmt "@[<hov 2>(@ %a,@ %a@ )@]" pp_a a pp_b b
 end
+
+module Opam = struct
+  module type Printable = sig
+    type t
+
+    val pp : t Fmt.t
+  end
+
+  module Make_Set (M : OpamStd.SET) (P : Printable with type t = M.elt) : sig
+    val pp : ?sep:unit Fmt.t -> M.t Fmt.t
+  end = struct
+    let pp ?sep = Fmt.iter ?sep M.iter P.pp
+  end
+end

--- a/lib/pp_combinators.mli
+++ b/lib/pp_combinators.mli
@@ -18,3 +18,15 @@ module Ocaml : sig
 
   val pair : 'a Fmt.t -> 'b Fmt.t -> ('a * 'b) Fmt.t
 end
+
+module Opam : sig
+  module type Printable = sig
+    type t
+
+    val pp : t Fmt.t
+  end
+
+  module Make_Set (M : OpamStd.SET) (P : Printable with type t = M.elt) : sig
+    val pp : ?sep:unit Fmt.t -> M.t Fmt.t
+  end
+end

--- a/lib/source_opam_config.mli
+++ b/lib/source_opam_config.mli
@@ -1,4 +1,4 @@
-(** Utilities for extracting configuraion from target packages opam
+(** Utilities for extracting configuration from target packages opam
     files available in the project sources in opam extensions *)
 
 open Import
@@ -6,6 +6,7 @@ open Import
 type t = {
   global_vars : OpamVariable.variable_contents String.Map.t option;
   repositories : OpamUrl.Set.t option;
+  opam_provided : OpamPackage.Name.Set.t option;
 }
 (** Type for solver configuration bits encoded in opam extensions
     of target packages opam files.

--- a/lib/source_opam_config.mli
+++ b/lib/source_opam_config.mli
@@ -1,5 +1,5 @@
 (** Utilities for extracting configuration from target packages opam
-    files available in the project sources in opam extensions *)
+    files available in the project sources in Opam extensions *)
 
 open Import
 

--- a/test/bin/opam-provided.t/opam-provided.opam
+++ b/test/bin/opam-provided.t/opam-provided.opam
@@ -1,0 +1,10 @@
+opam-version: "2.0"
+depends: [
+  "dune"
+  "b"
+]
+x-opam-monorepo-opam-repositories: [
+  "file://$OPAM_MONOREPO_CWD/minimal-repo"
+  "file://$OPAM_MONOREPO_CWD/repo"
+]
+x-opam-monorepo-opam-provided: "b"

--- a/test/bin/opam-provided.t/repo/packages/b/b.1/opam
+++ b/test/bin/opam-provided.t/repo/packages/b/b.1/opam
@@ -1,0 +1,11 @@
+opam-version: "2.0"
+depends: [
+  "dune"
+]
+dev-repo: "git+https://github.com/b/b"
+url {
+  src: "https://b.com/b.tbz"
+  checksum: [
+    "sha256=0000000000000000000000000000000000000000000000000000000000000000"
+  ]
+}

--- a/test/bin/opam-provided.t/repo/packages/depends-on-b/depends-on-b.1/opam
+++ b/test/bin/opam-provided.t/repo/packages/depends-on-b/depends-on-b.1/opam
@@ -1,0 +1,12 @@
+opam-version: "2.0"
+depends: [
+  "dune"
+  "b"
+]
+dev-repo: "git+https://github.com/b/depends-on-b"
+url {
+  src: "https://b.com/depends-on-b.tbz"
+  checksum: [
+    "sha256=0000000000000000000000000000000000000000000000000000000000000000"
+  ]
+}

--- a/test/bin/opam-provided.t/repo/repo
+++ b/test/bin/opam-provided.t/repo/repo
@@ -1,0 +1,1 @@
+opam-version: "2.0"

--- a/test/bin/opam-provided.t/reverse-transitive.opam
+++ b/test/bin/opam-provided.t/reverse-transitive.opam
@@ -1,0 +1,10 @@
+opam-version: "2.0"
+depends: [
+  "dune"
+  "depends-on-b"
+]
+x-opam-monorepo-opam-repositories: [
+  "file://$OPAM_MONOREPO_CWD/minimal-repo"
+  "file://$OPAM_MONOREPO_CWD/repo"
+]
+x-opam-monorepo-opam-provided: "depends-on-b"

--- a/test/bin/opam-provided.t/run.t
+++ b/test/bin/opam-provided.t/run.t
@@ -112,7 +112,7 @@ be ignored is not a string.
   42
 
   $ opam-monorepo lock warning > /dev/null
-  opam-monorepo: String or List required
+  opam-monorepo: Error in opam file $TESTCASE_ROOT/warning.opam, [8:31]-[8:33]: Expected a string or a list of strings, got: 42
   [1]
 
 Similarly, we accept a list but it needs to be a list of strings which this is
@@ -121,5 +121,5 @@ not:
   $ opam show --no-lint --raw -fx-opam-monorepo-opam-provided ./warning-list.opam
   42 "fourtytwo"
   $ opam-monorepo lock warning > /dev/null
-  opam-monorepo: String or List required
+  opam-monorepo: Error in opam file $TESTCASE_ROOT/warning.opam, [8:31]-[8:33]: Expected a string or a list of strings, got: 42
   [1]

--- a/test/bin/opam-provided.t/run.t
+++ b/test/bin/opam-provided.t/run.t
@@ -71,3 +71,21 @@ Since it is, we need to make its dependency, `b` also opam-provided.
   $ opam show --no-lint --raw -fdepends ./reverse-transitive.opam.locked | grep "b\""
   "b" {= "1"}
   "depends-on-b" {= "1"}
+
+Since we add a new custom stanza to the OPAM file, let's make sure we emit
+warnings when things are specified the wrong way, for example if the package to
+be ignored is not a string.
+
+  $ opam show --no-lint --raw -fx-opam-monorepo-opam-provided ./warning.opam
+  42
+
+  $ opam-monorepo lock warning 2>&1 | grep WARNING
+  opam-monorepo: [WARNING] Error parsing x-opam-monorepo-provided: String or List required, ignoring.
+
+Similarly, we accept a list but it needs to be a list of strings which this is
+not
+
+  $ opam show --no-lint --raw -fx-opam-monorepo-opam-provided ./warning-list.opam
+  42 "fourtytwo"
+  $ opam-monorepo lock warning-list 2>&1 | grep WARNING
+  opam-monorepo: [WARNING] Error parsing x-opam-monorepo-provided: String required, ignoring.

--- a/test/bin/opam-provided.t/run.t
+++ b/test/bin/opam-provided.t/run.t
@@ -89,12 +89,11 @@ Now for the reverse case, `depends-on-b` is `opam`-provided.
   $ opam show --no-lint --raw -fx-opam-monorepo-opam-provided ./reverse-transitive.opam
   "depends-on-b"
 
-We try to maximize the amount of packages to vendor, thus "b" is vendored
-here (as well as installed via `opam` as a dependency of "depends-on-b"):
+Since it is, we need to make its dependency, "b", also `opam`-provided.
 
   $ opam-monorepo lock reverse-transitive > /dev/null
   $ opam show --no-lint --raw -fdepends ./reverse-transitive.opam.locked
-  "b" {= "1" & vendor}
+  "b" {= "1"}
   "base-bigarray" {= "base"}
   "base-threads" {= "base"}
   "base-unix" {= "base"}

--- a/test/bin/opam-provided.t/run.t
+++ b/test/bin/opam-provided.t/run.t
@@ -1,0 +1,41 @@
+We have a package that should not be installed via opam. There might be various
+reasons we might not want that (e.g. it cannot be built with `dune`), it is
+meant as a helper binary etc.
+
+We start with a minimal opam-repository:
+
+  $ gen-minimal-repo
+
+We have a file that depends on package `b`.
+
+  $ opam show --no-lint --raw -fdepends ./vendored.opam
+  "dune" "b"
+
+This package does not set any `opam-provided` packages:
+
+  $ opam show --no-lint --raw -fx-opam-monorepo-opam-provided ./vendored.opam
+  
+
+It should lock successfully.
+
+  $ opam-monorepo lock vendored > /dev/null
+
+The lockfile should thus contain the package `b` and mark it as `vendor` since
+opam-monorepo will vendor it.
+
+  $ opam show --no-lint --raw -fdepends ./vendored.opam.locked | grep "\"b\""
+  "b" {= "1" & vendor}
+
+Let's now check with the same opam file but this one adds `opam-provided`.
+Asking for the value will return that `b` will be provided by opam:
+
+  $ opam show --no-lint --raw -fx-opam-monorepo-opam-provided ./opam-provided.opam
+  "b"
+  $ opam-monorepo lock opam-provided > /dev/null
+
+We should be seing that this package is not marked as `vendor` so if we run
+`opam` on it, it will install the package `b`.
+
+  $ opam show --no-lint --raw -fdepends ./opam-provided.opam.locked | grep "\"b\""
+  "b" {= "1"}
+

--- a/test/bin/opam-provided.t/run.t
+++ b/test/bin/opam-provided.t/run.t
@@ -89,7 +89,8 @@ Now for the reverse case, `depends-on-b` is `opam`-provided.
   $ opam show --no-lint --raw -fx-opam-monorepo-opam-provided ./reverse-transitive.opam
   "depends-on-b"
 
-Since it is, we need to make its dependency, "b", also `opam`-provided.
+We try to maximize the amount of packages to vendor, thus "b" is vendored
+here (as well as installed via `opam` as a dependency of "depends-on-b"):
 
   $ opam-monorepo lock reverse-transitive > /dev/null
   $ opam show --no-lint --raw -fdepends ./reverse-transitive.opam.locked

--- a/test/bin/opam-provided.t/run.t
+++ b/test/bin/opam-provided.t/run.t
@@ -79,13 +79,15 @@ be ignored is not a string.
   $ opam show --no-lint --raw -fx-opam-monorepo-opam-provided ./warning.opam
   42
 
-  $ opam-monorepo lock warning 2>&1 | grep WARNING
-  opam-monorepo: [WARNING] Error parsing x-opam-monorepo-provided: String or List required, ignoring.
+  $ opam-monorepo lock warning > /dev/null
+  opam-monorepo: String or List required
+  [1]
 
 Similarly, we accept a list but it needs to be a list of strings which this is
 not
 
   $ opam show --no-lint --raw -fx-opam-monorepo-opam-provided ./warning-list.opam
   42 "fourtytwo"
-  $ opam-monorepo lock warning-list 2>&1 | grep WARNING
-  opam-monorepo: [WARNING] Error parsing x-opam-monorepo-provided: String required, ignoring.
+  $ opam-monorepo lock warning > /dev/null
+  opam-monorepo: String or List required
+  [1]

--- a/test/bin/opam-provided.t/run.t
+++ b/test/bin/opam-provided.t/run.t
@@ -2,11 +2,11 @@ We have a package that should not be installed via Opam. There might be various
 reasons we might not want that (e.g., it cannot be built with Dune), it is
 meant as a helper binary etc.
 
-We start with a minimal [opam-repository]:
+We start with a minimal `opam-repository`:
 
   $ gen-minimal-repo
 
-We have a file that depends on package `b`.
+We have a file that depends on package "b".
 
   $ opam show --no-lint --raw -fdepends ./vendored.opam
   "dune" "b"
@@ -20,7 +20,7 @@ It should lock successfully.
 
   $ opam-monorepo lock vendored > /dev/null
 
-The lockfile should thus contain the package `b` and mark it as `vendor` since
+The lockfile should thus contain the package "b" and mark it as `vendor` since
 `opam-monorepo` will vendor it.
 
   $ opam show --no-lint --raw -fdepends ./vendored.opam.locked
@@ -35,14 +35,14 @@ The lockfile should thus contain the package `b` and mark it as `vendor` since
   "ocaml-options-vanilla" {= "1"}
 
 Let's now check with the same Opam file but this one adds `opam`-provided.
-Asking for the value will return that `b` will be provided by Opam:
+Asking for the value will return that "b" will be provided by Opam:
 
   $ opam show --no-lint --raw -fx-opam-monorepo-opam-provided ./opam-provided.opam
   "b"
   $ opam-monorepo lock opam-provided > /dev/null
 
 We should see that this package is not marked as `vendor` so if we run
-`opam` on it, it will install the package `b`.
+`opam` on it, it will install the package "b".
 
   $ opam show --no-lint --raw -fdepends ./opam-provided.opam.locked
   "b" {= "1"}
@@ -80,7 +80,7 @@ Locking it should work as usual
   "ocaml-config" {= "2"}
   "ocaml-options-vanilla" {= "1"}
 
-[depends-on-b] is vendored (since it can) but `b` is `opam`-provided. Neat.
+`depends-on-b` is vendored (since it can) but "b" is `opam`-provided. Neat.
 
 Now for the reverse case, `depends-on-b` is `opam`-provided.
 
@@ -89,7 +89,7 @@ Now for the reverse case, `depends-on-b` is `opam`-provided.
   $ opam show --no-lint --raw -fx-opam-monorepo-opam-provided ./reverse-transitive.opam
   "depends-on-b"
 
-Since it is, we need to make its dependency, `b`, also `opam`-provided.
+Since it is, we need to make its dependency, "b", also `opam`-provided.
 
   $ opam-monorepo lock reverse-transitive > /dev/null
   $ opam show --no-lint --raw -fdepends ./reverse-transitive.opam.locked

--- a/test/bin/opam-provided.t/run.t
+++ b/test/bin/opam-provided.t/run.t
@@ -23,8 +23,16 @@ It should lock successfully.
 The lockfile should thus contain the package `b` and mark it as `vendor` since
 opam-monorepo will vendor it.
 
-  $ opam show --no-lint --raw -fdepends ./vendored.opam.locked | grep "\"b\""
+  $ opam show --no-lint --raw -fdepends ./vendored.opam.locked
   "b" {= "1" & vendor}
+  "base-bigarray" {= "base"}
+  "base-threads" {= "base"}
+  "base-unix" {= "base"}
+  "dune" {= "2.9.1"}
+  "ocaml" {= "4.13.1"}
+  "ocaml-base-compiler" {= "4.13.1"}
+  "ocaml-config" {= "2"}
+  "ocaml-options-vanilla" {= "1"}
 
 Let's now check with the same opam file but this one adds `opam-provided`.
 Asking for the value will return that `b` will be provided by opam:
@@ -36,8 +44,16 @@ Asking for the value will return that `b` will be provided by opam:
 We should be seing that this package is not marked as `vendor` so if we run
 `opam` on it, it will install the package `b`.
 
-  $ opam show --no-lint --raw -fdepends ./opam-provided.opam.locked | grep "\"b\""
+  $ opam show --no-lint --raw -fdepends ./opam-provided.opam.locked
   "b" {= "1"}
+  "base-bigarray" {= "base"}
+  "base-threads" {= "base"}
+  "base-unix" {= "base"}
+  "dune" {= "2.9.1"}
+  "ocaml" {= "4.13.1"}
+  "ocaml-base-compiler" {= "4.13.1"}
+  "ocaml-config" {= "2"}
+  "ocaml-options-vanilla" {= "1"}
 
 What happens in the case that a package would be ok to vendor but the
 transitive dependency is opam-provided? In this case we have a package
@@ -52,9 +68,17 @@ depend transitively on an opam provided package.
 Locking it should work as usual
 
   $ opam-monorepo lock transitive > /dev/null
-  $ opam show --no-lint --raw -fdepends ./transitive.opam.locked | grep "b\""
+  $ opam show --no-lint --raw -fdepends ./transitive.opam.locked
   "b" {= "1"}
+  "base-bigarray" {= "base"}
+  "base-threads" {= "base"}
+  "base-unix" {= "base"}
   "depends-on-b" {= "1" & vendor}
+  "dune" {= "2.9.1"}
+  "ocaml" {= "4.13.1"}
+  "ocaml-base-compiler" {= "4.13.1"}
+  "ocaml-config" {= "2"}
+  "ocaml-options-vanilla" {= "1"}
 
 `depends-on-b` is vendored (since it can) but `b` is opam-provided. Neat.
 
@@ -65,12 +89,20 @@ Now for the reverse case, `depends-on-b` is opam-provided.
   $ opam show --no-lint --raw -fx-opam-monorepo-opam-provided ./reverse-transitive.opam
   "depends-on-b"
 
-Since it is, we need to make its dependency, `b` also opam-provided.
+Since it is, we need to make its dependency, `b`, also opam-provided.
 
   $ opam-monorepo lock reverse-transitive > /dev/null
-  $ opam show --no-lint --raw -fdepends ./reverse-transitive.opam.locked | grep "b\""
+  $ opam show --no-lint --raw -fdepends ./reverse-transitive.opam.locked
   "b" {= "1"}
+  "base-bigarray" {= "base"}
+  "base-threads" {= "base"}
+  "base-unix" {= "base"}
   "depends-on-b" {= "1"}
+  "dune" {= "2.9.1"}
+  "ocaml" {= "4.13.1"}
+  "ocaml-base-compiler" {= "4.13.1"}
+  "ocaml-config" {= "2"}
+  "ocaml-options-vanilla" {= "1"}
 
 Since we add a new custom stanza to the OPAM file, let's make sure we emit
 warnings when things are specified the wrong way, for example if the package to
@@ -84,7 +116,7 @@ be ignored is not a string.
   [1]
 
 Similarly, we accept a list but it needs to be a list of strings which this is
-not
+not:
 
   $ opam show --no-lint --raw -fx-opam-monorepo-opam-provided ./warning-list.opam
   42 "fourtytwo"

--- a/test/bin/opam-provided.t/run.t
+++ b/test/bin/opam-provided.t/run.t
@@ -93,7 +93,7 @@ Since it is, we need to make its dependency, `b`, also opam-provided.
 
   $ opam-monorepo lock reverse-transitive > /dev/null
   $ opam show --no-lint --raw -fdepends ./reverse-transitive.opam.locked
-  "b" {= "1"}
+  "b" {= "1" & vendor}
   "base-bigarray" {= "base"}
   "base-threads" {= "base"}
   "base-unix" {= "base"}

--- a/test/bin/opam-provided.t/run.t
+++ b/test/bin/opam-provided.t/run.t
@@ -123,3 +123,8 @@ not:
   $ opam-monorepo lock warning > /dev/null
   opam-monorepo: Error in opam file $TESTCASE_ROOT/warning.opam, [8:31]-[8:33]: Expected a string or a list of strings, got: 42
   [1]
+
+It should also work to pass the version of the compiler and be respected for
+both `opam`-provided packages as well as those to be vendored:
+
+  $ opam-monorepo lock opam-provided --ocaml-version=4.13.1 > /dev/null

--- a/test/bin/opam-provided.t/run.t
+++ b/test/bin/opam-provided.t/run.t
@@ -1,8 +1,8 @@
-We have a package that should not be installed via opam. There might be various
-reasons we might not want that (e.g. it cannot be built with `dune`), it is
+We have a package that should not be installed via Opam. There might be various
+reasons we might not want that (e.g., it cannot be built with Dune), it is
 meant as a helper binary etc.
 
-We start with a minimal opam-repository:
+We start with a minimal [opam-repository]:
 
   $ gen-minimal-repo
 
@@ -11,7 +11,7 @@ We have a file that depends on package `b`.
   $ opam show --no-lint --raw -fdepends ./vendored.opam
   "dune" "b"
 
-This package does not set any `opam-provided` packages:
+This package does not set any [opam]-provided packages:
 
   $ opam show --no-lint --raw -fx-opam-monorepo-opam-provided ./vendored.opam
   
@@ -21,7 +21,7 @@ It should lock successfully.
   $ opam-monorepo lock vendored > /dev/null
 
 The lockfile should thus contain the package `b` and mark it as `vendor` since
-opam-monorepo will vendor it.
+`opam-monorepo` will vendor it.
 
   $ opam show --no-lint --raw -fdepends ./vendored.opam.locked
   "b" {= "1" & vendor}
@@ -34,14 +34,14 @@ opam-monorepo will vendor it.
   "ocaml-config" {= "2"}
   "ocaml-options-vanilla" {= "1"}
 
-Let's now check with the same opam file but this one adds `opam-provided`.
-Asking for the value will return that `b` will be provided by opam:
+Let's now check with the same Opam file but this one adds `opam`-provided.
+Asking for the value will return that `b` will be provided by Opam:
 
   $ opam show --no-lint --raw -fx-opam-monorepo-opam-provided ./opam-provided.opam
   "b"
   $ opam-monorepo lock opam-provided > /dev/null
 
-We should be seing that this package is not marked as `vendor` so if we run
+We should see that this package is not marked as `vendor` so if we run
 `opam` on it, it will install the package `b`.
 
   $ opam show --no-lint --raw -fdepends ./opam-provided.opam.locked
@@ -56,9 +56,9 @@ We should be seing that this package is not marked as `vendor` so if we run
   "ocaml-options-vanilla" {= "1"}
 
 What happens in the case that a package would be ok to vendor but the
-transitive dependency is opam-provided? In this case we have a package
-`transitive` that depends on a package that depends on a package that will
-depend transitively on an opam provided package.
+transitive dependency is `opam`-provided? In this case we have a package
+`transitive` that depends on packages that will
+depend transitively on an `opam`-provided package.
 
   $ opam show --no-lint --raw -fdepends ./transitive.opam
   "dune" "depends-on-b"
@@ -80,16 +80,16 @@ Locking it should work as usual
   "ocaml-config" {= "2"}
   "ocaml-options-vanilla" {= "1"}
 
-`depends-on-b` is vendored (since it can) but `b` is opam-provided. Neat.
+[depends-on-b] is vendored (since it can) but `b` is `opam`-provided. Neat.
 
-Now for the reverse case, `depends-on-b` is opam-provided.
+Now for the reverse case, `depends-on-b` is `opam`-provided.
 
   $ opam show --no-lint --raw -fdepends ./reverse-transitive.opam
   "dune" "depends-on-b"
   $ opam show --no-lint --raw -fx-opam-monorepo-opam-provided ./reverse-transitive.opam
   "depends-on-b"
 
-Since it is, we need to make its dependency, `b`, also opam-provided.
+Since it is, we need to make its dependency, `b`, also `opam`-provided.
 
   $ opam-monorepo lock reverse-transitive > /dev/null
   $ opam show --no-lint --raw -fdepends ./reverse-transitive.opam.locked
@@ -104,8 +104,8 @@ Since it is, we need to make its dependency, `b`, also opam-provided.
   "ocaml-config" {= "2"}
   "ocaml-options-vanilla" {= "1"}
 
-Since we add a new custom stanza to the OPAM file, let's make sure we emit
-warnings when things are specified the wrong way, for example if the package to
+Since we add a new custom stanza to the Opam file, let's make sure we emit
+warnings when things are specified the wrong way, e.g., if the package to
 be ignored is not a string.
 
   $ opam show --no-lint --raw -fx-opam-monorepo-opam-provided ./warning.opam

--- a/test/bin/opam-provided.t/transitive.opam
+++ b/test/bin/opam-provided.t/transitive.opam
@@ -1,0 +1,10 @@
+opam-version: "2.0"
+depends: [
+  "dune"
+  "depends-on-b"
+]
+x-opam-monorepo-opam-repositories: [
+  "file://$OPAM_MONOREPO_CWD/minimal-repo"
+  "file://$OPAM_MONOREPO_CWD/repo"
+]
+x-opam-monorepo-opam-provided: "b"

--- a/test/bin/opam-provided.t/vendored.opam
+++ b/test/bin/opam-provided.t/vendored.opam
@@ -1,0 +1,9 @@
+opam-version: "2.0"
+depends: [
+  "dune"
+  "b"
+]
+x-opam-monorepo-opam-repositories: [
+  "file://$OPAM_MONOREPO_CWD/minimal-repo"
+  "file://$OPAM_MONOREPO_CWD/repo"
+]

--- a/test/bin/opam-provided.t/warning-list.opam
+++ b/test/bin/opam-provided.t/warning-list.opam
@@ -1,0 +1,8 @@
+opam-version: "2.0"
+depends: [
+  "dune"
+]
+x-opam-monorepo-opam-repositories: [
+  "file://$OPAM_MONOREPO_CWD/minimal-repo"
+]
+x-opam-monorepo-opam-provided: [42 "fourtytwo"]

--- a/test/bin/opam-provided.t/warning.opam
+++ b/test/bin/opam-provided.t/warning.opam
@@ -1,0 +1,8 @@
+opam-version: "2.0"
+depends: [
+  "dune"
+]
+x-opam-monorepo-opam-repositories: [
+  "file://$OPAM_MONOREPO_CWD/minimal-repo"
+]
+x-opam-monorepo-opam-provided: 42

--- a/test/lib/test_duniverse.ml
+++ b/test/lib/test_duniverse.ml
@@ -23,9 +23,9 @@ let opam_factory ~name ~version =
   OpamPackage.create name version
 
 let summary_factory ?(name = "undefined") ?(version = "1") ?dev_repo ?url_src
-    ?(hashes = []) ?(depexts = []) () =
+    ?(hashes = []) ?(depexts = []) ?(vendored = true) () =
   let package = opam_factory ~name ~version in
-  { Opam.Package_summary.package; dev_repo; url_src; hashes; depexts }
+  { Opam.Package_summary.package; dev_repo; url_src; hashes; depexts; vendored }
 
 module Repo = struct
   module Package = struct
@@ -53,6 +53,11 @@ module Repo = struct
           ~expected:(Ok None) ();
         make_test ~name:"No dev_repo"
           ~summary:(summary_factory ?dev_repo:None ())
+          ~expected:(Ok None) ();
+        make_test ~name:"Non-vendored"
+          ~summary:
+            (summary_factory ~dev_repo:"d" ~url_src:(Other "u") ~name:"y"
+               ~version:"v" ~vendored:false ())
           ~expected:(Ok None) ();
         make_test ~name:"Regular"
           ~summary:


### PR DESCRIPTION
This is a draft PR on the hybrid mode feature, which makes it possible to actually test things and go somewhere from there.

1. Packages to be installed via `opam` can't be marked as not-installable in the solver because in such case there is no solution. I explored this avenue and it doesn't lead anywhere. At least one part of the solution space eliminated :heavy_check_mark: 
1. There's currently warnings about `opam-provided`, our custom variable. Not great.
1. Variables are false by default so packages marked this way will not be picked up by opam.
1. The detection of the variable is extremely inflexible now. This is just (very necessary) busywork to walk that formula and determine whether the variable is set but needs to be done before release. For testing the concept on examples this works ok. 
1. It needs a command to install the `opam-provided` packages. That's the easiest part so I'm leaving it for last, once we have figured out the other problems just collecting packages to install should be simple.

(No changelog entry because it shouldn't be merged and also for a decent changelog entry I'd want to have the functionality in place so I know what to describe)

But what works is:
1. Mark a package as `opam-provided` in the `opam`/`dune-project` file, e.g. `bos` like in this PR
1. Run `opam-monorepo lock`
1. See that `bos` and its dependencies like `fpath`, `rresult` and friends aren't part of the lockfile anymore, so they wouldn't be pulled anymore.