### PR TITLE
Fix a bug in `Lockfile.to_duniverse` that duplicated provided_packages

### DIFF
--- a/lib/lockfile.ml
+++ b/lib/lockfile.ml
@@ -308,7 +308,7 @@ let to_duniverse { duniverse_dirs; pin_depends; _ } =
   let packages_per_url =
     List.fold_left pin_depends ~init:OpamUrl.Map.empty
       ~f:(fun acc (package, url) ->
-        OpamUrl.Map.update url (fun l -> package :: l) [ package ] acc)
+        OpamUrl.Map.update url (fun l -> package :: l) [] acc)
     |> OpamUrl.Map.bindings
   in
   Result.List.map packages_per_url ~f:(fun (url, packages) ->


### PR DESCRIPTION
The bug was discovered by @samoht in #217. When rebuilding a `Duniverse.t` from a `Lockfile.t`, some packages in the `provided_packages` list would be duplicated, one for every repo in the duniverse.

This was due to a misinterpretation of the `OpamStd.Map.update` arguments semantic.

I did not add a changelog entry as this bug was not observable from the outside, the provided packages are not used by pull so it had no impact until we started working on the `list` subcommand.

A good follow up to this might be to clean up our internal representation to use a `Set` there since we want to express the uniqueness.