### PR TITLE
Add documentation for opam-monorepo

### DIFF
--- a/doc/concepts.mld
+++ b/doc/concepts.mld
@@ -1,0 +1,18 @@
+{1 Concepts}
+
+An [opam-monorepo] project uses 3 components in the source tree:
+- a set of opam files containing specifications about the dependencies (for
+  example, a dependency on [lwt >= 4.0.0])
+- a lockfile (with extension [.opam.locked]) containing references to exact
+  dependencies (for example, [lwt = 4.2.1]) and how to get them (URLs, hashes,
+  etc.). It also contains information about transitive dependencies, not just
+  the ones mentioned in opam files.
+- a [duniverse] folder, which contains the sources for all the packages
+  mentioned in the lockfile
+
+The two important commands are:
+- [opam monorepo lock], which will read the Opam file and compute a solution
+  using the Opam repository and the Opam solver. It will create or update the
+  lockfile with this solution.
+- [opam monorepo pull] will read the lockfile, download the dependencies, and
+  unpack them into the [duniverse/] folder.

--- a/doc/dune
+++ b/doc/dune
@@ -1,0 +1,1 @@
+(documentation)

--- a/doc/faq.mld
+++ b/doc/faq.mld
@@ -1,0 +1,52 @@
+{1 FAQ}
+
+{2 Is This For Me?}
+
+This might be the right thing for you if all your dependencies use Dune and you
+are under full control of the build and deployment pipeline for your piece of
+software (e.g., if you are in a position to write a [dune-workspace] file).
+
+For example:
+- You are building and deploying a piece of software in a Docker image.
+- You are building a website using a static-site generator and examples checked
+  with MDX.
+- You are checking the impact of some changes in a library and all packages that
+  depend on it.
+
+{2 About Opam}
+
+Opam is a package manager that
+- determines which versions of a library to use for a project
+- executes build instructions for each of them so that a compiled form is
+  available
+
+Instead of the second step, [opam-monorepo] copies the source code of these
+dependencies into a Dune workspace, which Dune compiles directly.
+
+In a way, this is a new kind of package management that uses source code in
+every step:
+
+- "Binary" package managers (apt, rpm) download the code as binary and install
+  it as binary.
+- "Source" package managers download the code as source and install it as
+  binary. Opam is in this category.
+- opam-monorepo downloads code as source and installs it as source.
+
+{2 New Workflows [opam-monorepo] Enable}
+
+With the sources available, certain tasks are easier:
+- Using Merlin to navigate the project (there's no distinction between jumping
+  to a definition in the project’s code or in its dependencies)
+- Editing a dependency and rebuilding the project (even in watch mode)
+- Upstreaming changes made to dependencies (a dependency is just a subdirectory)
+- Cross-compilation - the details of how to build some native code can come late
+  in the pipeline, which isn't a problem if the sources are available
+
+{2 Why is [opam monorepo] an Opam Plugin?}
+
+Even though [opam-monorepo] doesn't require installing packages through Opam, it
+is  distributed as an Opam plugin. There are two reasons for this:
+- It uses Opam libraries internally to interact with the package repository and
+  respect the local Opam configuration (repositories, pins, etc.)
+- Opam plugins have a special behaviour; they can be installed globally, so one
+  does not have to install [opam-monorepo] through Opam in various projects.

--- a/doc/index.mld
+++ b/doc/index.mld
@@ -1,0 +1,11 @@
+{0 [opam monorepo] Docs}
+
+[opam-monorepo] is an Opam plugin that assembles a Dune workspace for an OCaml
+project using a precise lock file. When a project is in the same workspace as
+all of its dependencies, it's self-contained, so Dune can build it without
+relying on Opam or external system libraries.
+
+Table of contents:
+- {{!page-faq}A FAQ} to answer common questions about [opam monorepo]
+- {{!page-concepts}A description of the concepts} behind [opam monorepo].
+- Some {{!page-workflows}common workflows} used in [opam monorepo] projects.

--- a/doc/workflows.mld
+++ b/doc/workflows.mld
@@ -1,0 +1,137 @@
+{1 Workflows}
+
+This section documents day-to-day tasks in a project that uses [opam-monorepo].
+
+{2 Initial Setup}
+
+There are several ways to configure a project to use [opam-monorepo], depending
+on what is checked into Git.
+- {b (Recommended)} {e lockfile-in-git}: only check lockfile into Git. Everybody
+  gets a consistent view of the dependencies, but developers are responsible for
+running [opam monorepo pull].
+- {e duniverse-in-git}: check lockfile and duniverse folder into Git. This
+  ensures that the repository is self-contained, but it can be very large.
+- {e not-locked}: Everybody is responsible for generating a lockfile. Different
+  people can end up with different dependencies. This is not really an
+  [opam-monorepo] workflow, but it is a way [opam-monorepo] can be used to build
+  a project even if it doesn't use [opam-monorepo].
+
+As a summary:
+
+- {e lockfile-in-git}: opam file and lockfile checked in, duniverse ignored.
+- {e duniverse-in-git}: opam file, lockfile and duniverse checked in.
+- {e not-locked}: opam file checked in, lockfile and duniverse not checked in.
+
+We recommend using the {e lockfile-in-git} workflow. To enable it, first
+generate a lockfile (using [opam monorepo lock]), add it to your Git repository,
+together with [project.opam], and add [duniverse/] in [.gitignore].
+
+{2 Setting Up Continuous Integration}
+
+Note: if you use {{: https://ci.ocamllabs.io/} ocaml-ci}, you don't have
+anything to do. It will detect [opam-monorepo] builds and replace the Opam-based
+builds by an [opam-monorepo] aware build that implements the rest of this
+section.
+
+This section is useful if you want to implement a CI system based on
+[opam-monorepo].
+
+A build consists in three steps:
+{ol
+{- Set up the environment}
+{- Set up the workspace}
+{- Build the project}
+}
+
+{3 Set Up the Environment}
+
+In this context, "the environment" is a set of programs to be put in [$PATH]. An
+[opam-monorepo] build requires an OCaml compiler, Dune, and [opam-monorepo]. The
+project might require system packages ("depexts") too. It's possible to rely on
+[opam] to install this environment, but it's not technically required.
+
+The following assumes that Opam is being used.
+
+To set up the environment:
+- It's only necessary to have access to the lockfile (the Opam file, Duniverse
+  folder, and source code are not used)
+- Create an Opam switch compatible with the OCaml version mentioned in the
+  lockfile
+- Install Dune. The latest version usually works
+- Install [opam-monorepo]. The version to pick depends the lockfile format
+  version ([x-opam-monorepo-version] field in the lockfile). The rule is that a
+  lockfile with version {e 0.N} can be interpreted by [opam-monorepo] version
+  [0.N.*], but in most cases, [opam-monorepo] can read older versions. As
+  [opam-monorepo] reaches version 1.0.0, more stability guarantees will exist.
+- Install depexts. Since format version 0.2, all depexts are recorded in the
+  lockfile, so they can be listed using [opam show -f depexts
+  ./project.opam.locked]. In a future version, a command [opam monorepo depext]
+  will provide a way to install them directly.
+
+{3 Setup the Workspace}
+
+The next step is to set up a workspace that contains your project and its
+dependencies.
+- This step requires access to the lockfile and a way to download Opam packages.
+- Run [opam monorepo pull].
+
+{3 Build the Project}
+
+In this step, the workspace is ready, so [dune build] commands can succeed. The
+exact command to run depends on the project, but for CI, [dune build] followed
+by [dune runtest] is usually the right thing to do (or in a single step, [dune
+build @all @runtest]). If the goal of that pipeline is to produce release
+binaries, passing [--profile release] might be better. Consult the Dune
+documentation to know more about the difference.
+
+{3 Caching Strategies}
+
+This build skeleton can benefit from several caching strategies.
+The first one is to use a layering approach, e.g., by using Docker.
+
+Most of the steps only require the lockfile, so they can be cached and
+invalidated when the lockfile changes.
+
+For the OCaml compiler version, this can be a bit too conservative, as it will
+cause any change in the lockfile to rebuild a switch. Instead, it's possible to
+hardcode the OCaml compiler version in the Docker file, and only check that the
+version is correct during the "setup environment" phase.
+
+Doing only this will start all builds with an empty [_build] directory, so all
+dependencies need to be built each time. One solution to this is to persist the
+[_build] directory between builds. This can even be done across branches (the
+cache key is just the project name).
+
+For local development, this means that [_build] is expensive to rebuild
+(similarly to a local Opam switch). It is possible to set up a machine-global
+{{: https://dune.readthedocs.io/en/stable/caching.html} dune cache} to speed up
+rebuilds.
+
+{2 Upgrading all Dependencies}
+
+To upgrade dependencies, run [opam monorepo lock]. It will compute a new
+solution based on the constraints in [project.opam] and the current state of
+opam-repository. Then locally run [opam monorepo pull] to update the
+[duniverse/] folder.
+
+It is recommended to regularly create pull requests to update dependencies. When
+updating a local copy, developers will need to call [opam monorepo pull].
+
+{2 Adding a Dependency}
+
+Note: this section also applies to all the cases where there are changes to the
+dependencies in [project.opam], for example if a version constraint is modified.
+
+To add a dependency:
+- Add it to [project.opam] (directly or if you use opam file generation, add it
+  to [dune-project] and run [dune build]).
+- Regenerate the lock file using [opam monorepo lock].
+- Locally update the [duniverse/] folder using [opam monorepo pull].
+- Open a PR with the changes to [project.opam], the lockfile and optionally
+  [dune-project].
+
+This has the side effect of upgrading all dependencies too. To get a more
+conservative upgrade, one can do the upgrade in two steps:
+- First, open a PR to update all dependencies as described above.
+- Then open a PR adding a dependency. It will only contain changes relevant to
+  that dependency.


### PR DESCRIPTION
This contains a FAQ, a description of the concepts and files, and some workflows.

It is integrated with `dune build @doc` but it is probably up to us to build and host the generated HTML.
