### PR TITLE
Vendor variable in lockfile

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@
 
 ### Changed
 
+- Mark packages to be pulled by opam-monorepo with the `vendor` variable so
+  using OPAM with `opam install --deps-only --locked .` will not install
+  packages that will be installed with `opam-monorepo pull` (#<PR_NUMBER>,
+  @Leonidas-from-XIV)
+
 ### Deprecated
 
 ### Fixed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
 
 - Mark packages to be pulled by opam-monorepo with the `vendor` variable so
   using OPAM with `opam install --deps-only --locked .` will not install
-  packages that will be installed with `opam-monorepo pull` (#<PR_NUMBER>,
+  packages that will be installed with `opam-monorepo pull` (#237,
   @Leonidas-from-XIV)
 
 ### Deprecated

--- a/cli/list_cmd.ml
+++ b/cli/list_cmd.ml
@@ -48,7 +48,7 @@ let pp ~max_name ~max_version ~short ppf t =
 
 let pkgs_of_repo (t : resolved Repo.t) =
   List.map
-    ~f:(fun (pkg : Opam.t) ->
+    ~f:(fun (pkg : OpamPackage.t) ->
       let name = pkg.name in
       let version = pkg.version in
       let loc = Repo.Url.to_string t.url in

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -49,3 +49,6 @@ let dune_src_dir = Fpath.(bootstrap_src_dir / "dune")
 let dune_latest_tag = "2.6.0" (* TODO get from opam metadata *)
 
 let lockfile_ext = ".opam.locked"
+
+(* variable to use for vendoring *)
+let vendor_variable = OpamVariable.of_string "vendor"

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -13,6 +13,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
  *)
+open Import
 
 let base_packages =
   [
@@ -26,6 +27,8 @@ let base_packages =
     "ocaml-base-compiler";
     "ocaml-variants";
   ]
+  |> List.map ~f:OpamPackage.Name.of_string
+  |> OpamPackage.Name.Set.of_list
 
 let duniverse_opam_repo =
   "git+https://github.com/dune-universe/opam-overlays.git"

--- a/lib/duniverse.ml
+++ b/lib/duniverse.ml
@@ -6,25 +6,26 @@ type unresolved = Git.Ref.t
 type resolved = Git.Ref.resolved
 
 module Opam = struct
-  type t = { name : string; version : string }
+  type t = { name : OpamPackage.Name.t; version : string }
 
   let equal t t' =
     let { name; version } = t in
     let { name = name'; version = version' } = t' in
-    String.equal name name' && String.equal version version'
+    OpamPackage.Name.equal name name' && String.equal version version'
 
-  let pp fmt { name; version } = Format.fprintf fmt "%s.%s" name version
+  let pp fmt { name; version } =
+    Format.fprintf fmt "%a.%s" Opam.Pp.package_name name version
 
   let raw_pp fmt { name; version } =
     let open Pp_combinators.Ocaml in
-    Format.fprintf fmt "@[<hov 2>{ name = %a;@ version = %a }@]" string name
-      string version
+    Format.fprintf fmt "@[<hov 2>{ name = %a;@ version = %a }@]"
+      Opam.Pp.package_name name string version
 
   let to_opam { name = n; version = v } =
-    OpamPackage.(create (Name.of_string n) (Version.of_string v))
+    OpamPackage.(create n (Version.of_string v))
 
   let from_opam pkg =
-    let name = OpamPackage.name_to_string pkg in
+    let name = OpamPackage.name pkg in
     let version = OpamPackage.version_to_string pkg in
     { name; version }
 end
@@ -136,7 +137,8 @@ module Repo = struct
       | Other s -> s
     in
     let pp_package fmt { Package.opam = { name; version }; url; _ } =
-      Format.fprintf fmt "%s.%s: %s" name version (url_to_string url)
+      Format.fprintf fmt "%a.%s: %s" O.Pp.package_name name version
+        (url_to_string url)
     in
     let sep fmt () = Format.fprintf fmt "\n" in
     Logs.info (fun l ->

--- a/lib/duniverse.ml
+++ b/lib/duniverse.ml
@@ -1,28 +1,8 @@
 open Import
-module O = Opam
 
 type unresolved = Git.Ref.t
 
 type resolved = Git.Ref.resolved
-
-(* TODO: remove? *)
-module Opam = struct
-  type t = OpamPackage.t
-
-  let equal = OpamPackage.equal
-
-  let pp fmt pkg =
-    Format.fprintf fmt "%a.%a" Opam.Pp.package_name pkg.OpamPackage.name
-      Opam.Pp.version pkg.version
-
-  let raw_pp fmt pkg =
-    Format.fprintf fmt "@[<hov 2>{ name = %a;@ version = %a }@]"
-      Opam.Pp.package_name pkg.OpamPackage.name Opam.Pp.version pkg.version
-
-  let to_opam x = x
-
-  let from_opam x = x
-end
 
 module Repo = struct
   module Url = struct
@@ -66,23 +46,23 @@ module Repo = struct
     let to_opam_url t = opam_url_from_string (to_string t)
 
     let from_opam_url opam_url =
-      match O.Url.from_opam opam_url with
-      | O.Url.Other s -> Ok (Other s)
-      | O.Url.Git { repo; ref = Some commit } ->
+      match Opam.Url.from_opam opam_url with
+      | Opam.Url.Other s -> Ok (Other s)
+      | Opam.Url.Git { repo; ref = Some commit } ->
           Ok (Git { repo; ref = { Git.Ref.t = commit; commit } })
       | _ -> Error (`Msg "Git URL must be resolved to a commit hash")
   end
 
   module Package = struct
     type t = {
-      opam : Opam.t;
+      opam : OpamPackage.t;
       dev_repo : string;
       url : unresolved Url.t;
       hashes : OpamHash.t list;
     }
 
     let equal t t' =
-      Opam.equal t.opam t'.opam
+      OpamPackage.equal t.opam t'.opam
       && String.equal t.dev_repo t'.dev_repo
       && Url.equal Git.Ref.equal t.url t'.url
 
@@ -90,14 +70,14 @@ module Repo = struct
       let open Pp_combinators.Ocaml in
       Format.fprintf fmt
         "@[<hov 2>{ opam = %a;@ dev_repo = %a;@ url = %a;@ hashes = %a }@]"
-        Opam.raw_pp opam string dev_repo (Url.pp Git.Ref.pp) url
-        (list O.Pp.hash) hashes
+        Opam.Pp.raw_package opam string dev_repo (Url.pp Git.Ref.pp) url
+        (list Opam.Pp.hash) hashes
 
     let from_package_summary ~get_default_branch ps =
-      let open O.Package_summary in
+      let open Opam.Package_summary in
       let open Result.O in
       let url ourl =
-        match (ourl : O.Url.t) with
+        match (ourl : Opam.Url.t) with
         | Other s -> Ok (Url.Other s)
         | Git { repo; ref = Some ref } -> Ok (Url.Git { repo; ref })
         | Git { repo; ref = None } ->
@@ -116,7 +96,7 @@ module Repo = struct
     dir : string;
     url : 'ref Url.t;
     hashes : OpamHash.t list;
-    provided_packages : Opam.t list;
+    provided_packages : OpamPackage.t list;
   }
 
   let log_url_selection ~dev_repo ~packages ~highest_version_package =
@@ -125,8 +105,8 @@ module Repo = struct
       | Other s -> s
     in
     let pp_package fmt { Package.opam = { name; version }; url; _ } =
-      Format.fprintf fmt "%a.%a: %s" O.Pp.package_name name O.Pp.version version
-        (url_to_string url)
+      Format.fprintf fmt "%a.%a: %s" Opam.Pp.package_name name Opam.Pp.version
+        version (url_to_string url)
     in
     let sep fmt () = Format.fprintf fmt "\n" in
     Logs.info (fun l ->
@@ -188,16 +168,16 @@ module Repo = struct
     in
     String.equal dir dir'
     && Url.equal equal_ref url url'
-    && List.equal O.Hash.equal hashes hashes'
-    && List.equal Opam.equal provided_packages provided_packages'
+    && List.equal Opam.Hash.equal hashes hashes'
+    && List.equal OpamPackage.equal provided_packages provided_packages'
 
   let pp pp_ref fmt { dir; url; hashes; provided_packages } =
     let open Pp_combinators.Ocaml in
     Format.fprintf fmt
       "@[<hov 2>{ dir = %a;@ url = %a;@ hashes = %a;@ provided_packages = %a \
        }@]"
-      string dir (Url.pp pp_ref) url (list O.Pp.hash) hashes (list Opam.raw_pp)
-      provided_packages
+      string dir (Url.pp pp_ref) url (list Opam.Pp.hash) hashes
+      (list Opam.Pp.raw_package) provided_packages
 
   let resolve ~resolve_ref ({ url; _ } as t) =
     let open Result.O in

--- a/lib/duniverse.ml
+++ b/lib/duniverse.ml
@@ -5,28 +5,23 @@ type unresolved = Git.Ref.t
 
 type resolved = Git.Ref.resolved
 
+(* TODO: remove? *)
 module Opam = struct
-  type t = { name : OpamPackage.Name.t; version : OpamPackage.Version.t }
+  type t = OpamPackage.t
 
-  let equal t t' =
-    let { name; version } = t in
-    let { name = name'; version = version' } = t' in
-    OpamPackage.Name.equal name name'
-    && OpamPackage.Version.equal version version'
+  let equal = OpamPackage.equal
 
-  let pp fmt { name; version } =
-    Format.fprintf fmt "%a.%a" Opam.Pp.package_name name Opam.Pp.version version
+  let pp fmt pkg =
+    Format.fprintf fmt "%a.%a" Opam.Pp.package_name pkg.OpamPackage.name
+      Opam.Pp.version pkg.version
 
-  let raw_pp fmt { name; version } =
+  let raw_pp fmt pkg =
     Format.fprintf fmt "@[<hov 2>{ name = %a;@ version = %a }@]"
-      Opam.Pp.package_name name Opam.Pp.version version
+      Opam.Pp.package_name pkg.OpamPackage.name Opam.Pp.version pkg.version
 
-  let to_opam { name; version } = OpamPackage.create name version
+  let to_opam x = x
 
-  let from_opam pkg =
-    let name = OpamPackage.name pkg in
-    let version = OpamPackage.version pkg in
-    { name; version }
+  let from_opam x = x
 end
 
 module Repo = struct
@@ -111,16 +106,10 @@ module Repo = struct
       match ps with
       | _ when is_base_package ps -> Ok None
       | { url_src = None; _ } | { dev_repo = None; _ } -> Ok None
-      | {
-       url_src = Some url_src;
-       name;
-       version;
-       dev_repo = Some dev_repo;
-       hashes;
-       _;
-      } ->
+      | { url_src = Some url_src; package; dev_repo = Some dev_repo; hashes; _ }
+        ->
           url url_src >>= fun url ->
-          Ok (Some { opam = { name; version }; dev_repo; url; hashes })
+          Ok (Some { opam = package; dev_repo; url; hashes })
   end
 
   type 'ref t = {

--- a/lib/duniverse.mli
+++ b/lib/duniverse.mli
@@ -5,7 +5,7 @@ type unresolved = Git.Ref.t
 type resolved = Git.Ref.resolved
 
 module Opam : sig
-  type t = { name : string; version : string }
+  type t = { name : OpamPackage.Name.t; version : string }
   (** Type of dependencies to install through opam *)
 
   val equal : t -> t -> bool

--- a/lib/duniverse.mli
+++ b/lib/duniverse.mli
@@ -5,7 +5,7 @@ type unresolved = Git.Ref.t
 type resolved = Git.Ref.resolved
 
 module Opam : sig
-  type t = { name : OpamPackage.Name.t; version : OpamPackage.Version.t }
+  type t = OpamPackage.t
   (** Type of dependencies to install through opam *)
 
   val equal : t -> t -> bool

--- a/lib/duniverse.mli
+++ b/lib/duniverse.mli
@@ -1,21 +1,6 @@
-module O = Opam
-
 type unresolved = Git.Ref.t
 
 type resolved = Git.Ref.resolved
-
-module Opam : sig
-  type t = OpamPackage.t
-  (** Type of dependencies to install through opam *)
-
-  val equal : t -> t -> bool
-
-  val pp : t Fmt.t
-
-  val to_opam : t -> OpamPackage.t
-
-  val from_opam : OpamPackage.t -> t
-end
 
 module Repo : sig
   module Url : sig
@@ -38,7 +23,7 @@ module Repo : sig
     dir : string;
     url : 'ref Url.t;
     hashes : OpamHash.t list;
-    provided_packages : Opam.t list;
+    provided_packages : OpamPackage.t list;
   }
   (** Type of dependencies to clone in the duniverse *)
 
@@ -52,7 +37,7 @@ module Repo : sig
 
   module Package : sig
     type t = {
-      opam : Opam.t;
+      opam : OpamPackage.t;
       dev_repo : string;
       url : unresolved Url.t;
       hashes : OpamHash.t list;
@@ -64,7 +49,7 @@ module Repo : sig
 
     val from_package_summary :
       get_default_branch:(string -> (string, Rresult.R.msg) result) ->
-      O.Package_summary.t ->
+      Opam.Package_summary.t ->
       (t option, [ `Msg of string ]) result
   end
 
@@ -80,7 +65,7 @@ val equal : t -> t -> bool
 
 val from_package_summaries :
   get_default_branch:(string -> (string, Rresult.R.msg) result) ->
-  O.Package_summary.t list ->
+  Opam.Package_summary.t list ->
   (unresolved Repo.t list, [ `Msg of string ]) result
 (** Build opamverse and duniverse from a list of [Types.Opam.entry] values.
     It filters out virtual packages and packages with unknown dev-repo.  *)

--- a/lib/duniverse.mli
+++ b/lib/duniverse.mli
@@ -5,7 +5,7 @@ type unresolved = Git.Ref.t
 type resolved = Git.Ref.resolved
 
 module Opam : sig
-  type t = { name : OpamPackage.Name.t; version : string }
+  type t = { name : OpamPackage.Name.t; version : OpamPackage.Version.t }
   (** Type of dependencies to install through opam *)
 
   val equal : t -> t -> bool

--- a/lib/lockfile.ml
+++ b/lib/lockfile.ml
@@ -215,7 +215,7 @@ module Pin_depends = struct
     let open Duniverse.Repo in
     List.concat_map l ~f:(fun { provided_packages; url; _ } ->
         let url = Url.to_opam_url url in
-        List.map provided_packages ~f:(fun p -> (Duniverse.Opam.to_opam p, url)))
+        List.map provided_packages ~f:(fun p -> (p, url)))
 
   let sort t =
     List.sort ~cmp:(fun (pkg, _) (pkg', _) -> OpamPackage.compare pkg pkg') t
@@ -357,7 +357,7 @@ let to_duniverse { duniverse_dirs; pin_depends; _ } =
         OpamUrl.Map.update url (fun l -> package :: l) [] acc)
     |> OpamUrl.Map.bindings
   in
-  Result.List.map packages_per_url ~f:(fun (url, packages) ->
+  Result.List.map packages_per_url ~f:(fun (url, provided_packages) ->
       match OpamUrl.Map.find_opt url duniverse_dirs with
       | None ->
           let msg =
@@ -367,9 +367,6 @@ let to_duniverse { duniverse_dirs; pin_depends; _ } =
           in
           Error (`Msg msg)
       | Some (dir, hashes) ->
-          let provided_packages =
-            List.map packages ~f:Duniverse.Opam.from_opam
-          in
           url_to_duniverse_url url >>= fun url ->
           Ok { Duniverse.Repo.dir; url; hashes; provided_packages })
 

--- a/lib/lockfile.ml
+++ b/lib/lockfile.ml
@@ -131,10 +131,8 @@ module Root_packages = struct
 end
 
 module Depends = struct
-  type version = string
-
   type t = {
-    dependencies : (OpamPackage.Name.t * version) list;
+    dependencies : (OpamPackage.Name.t * OpamPackage.Version.t) list;
     vendored : OpamPackage.Name.Set.t;
   }
 
@@ -163,7 +161,10 @@ module Depends = struct
   let from_filtered_formula formula =
     let open OpamTypes in
     let atoms = OpamFormula.ands_to_list formula in
-    let dependency name version = (name, version) in
+    let dependency name version =
+      let version = OpamPackage.Version.of_string version in
+      (name, version)
+    in
     Result.List.fold_left atoms
       ~init:{ dependencies = []; vendored = OpamPackage.Name.Set.empty }
       ~f:(fun { dependencies; vendored } -> function
@@ -196,7 +197,9 @@ module Depends = struct
         (OpamTypes.Filter (OpamTypes.FIdent ([], Config.vendor_variable, None)))
     in
     let version_constraint =
-      OpamFormula.Atom (OpamTypes.Constraint (`Eq, OpamTypes.FString version))
+      OpamFormula.Atom
+        (OpamTypes.Constraint
+           (`Eq, OpamTypes.FString (OpamPackage.Version.to_string version)))
     in
     let is_vendored = OpamPackage.Name.Set.mem name vendored in
     let formula =

--- a/lib/opam.ml
+++ b/lib/opam.ml
@@ -128,6 +128,10 @@ module Pp = struct
 
   let version = Fmt.using OpamPackage.Version.to_string Fmt.string
 
+  let raw_package fmt pkg =
+    Format.fprintf fmt "@[<hov 2>{ name = %a;@ version = %a }@]" package_name
+      pkg.OpamPackage.name version pkg.version
+
   let hash = Hash.pp
 
   let url = Fmt.using OpamUrl.to_string Fmt.string

--- a/lib/opam.ml
+++ b/lib/opam.ml
@@ -135,36 +135,32 @@ end
 
 module Package_summary = struct
   type t = {
-    name : OpamPackage.Name.t;
-    version : OpamPackage.Version.t;
+    package : OpamPackage.t;
     url_src : Url.t option;
     hashes : OpamHash.t list;
     dev_repo : string option;
     depexts : (OpamSysPkg.Set.t * OpamTypes.filter) list;
   }
 
-  let equal { name; version; url_src; hashes; dev_repo; depexts } t' =
-    OpamPackage.Name.equal name t'.name
-    && OpamPackage.Version.equal version t'.version
+  let equal { package; url_src; hashes; dev_repo; depexts } t' =
+    OpamPackage.equal package t'.package
     && Option.equal Url.equal url_src t'.url_src
     && List.equal Hash.equal hashes t'.hashes
     && Option.equal String.equal dev_repo t'.dev_repo
     && Depexts.equal depexts t'.depexts
 
-  let pp fmt { name; version; url_src; hashes; dev_repo; depexts } =
+  let pp fmt { package; url_src; hashes; dev_repo; depexts } =
     let open Pp_combinators.Ocaml in
     Format.fprintf fmt
       "@[<hov 2>{ name = %a;@ version = %a;@ url_src = %a;@ hashes = %a;@ \
        dev_repo = %a;@ depexts = %a }@]"
-      Pp.package_name name Pp.version version
+      Pp.package_name package.name Pp.version package.version
       (option ~brackets:true Url.pp)
       url_src (list Hash.pp) hashes
       (option ~brackets:true string)
       dev_repo Depexts.pp depexts
 
-  let from_opam ~pkg opam_file =
-    let name = OpamPackage.name pkg in
-    let version = OpamPackage.version pkg in
+  let from_opam ~pkg:package opam_file =
     let url_field = OpamFile.OPAM.url opam_file in
     let url_src = Option.map ~f:Url.from_opam_field url_field in
     let hashes =
@@ -174,7 +170,7 @@ module Package_summary = struct
       Option.map ~f:OpamUrl.to_string (OpamFile.OPAM.dev_repo opam_file)
     in
     let depexts = OpamFile.OPAM.depexts opam_file in
-    { name; version; url_src; hashes; dev_repo; depexts }
+    { package; url_src; hashes; dev_repo; depexts }
 
   let is_virtual = function
     | { url_src = None; _ } -> true
@@ -182,7 +178,8 @@ module Package_summary = struct
     | _ -> false
 
   let is_base_package = function
-    | { name; _ } when OpamPackage.Name.Set.mem name Config.base_packages ->
+    | { package; _ }
+      when OpamPackage.Name.Set.mem package.name Config.base_packages ->
         true
     | _ -> false
 end

--- a/lib/opam.ml
+++ b/lib/opam.ml
@@ -126,6 +126,8 @@ module Pp = struct
 
   let package_name = Fmt.using OpamPackage.Name.to_string Fmt.string
 
+  let version = Fmt.using OpamPackage.Version.to_string Fmt.string
+
   let hash = Hash.pp
 
   let url = Fmt.using OpamUrl.to_string Fmt.string
@@ -134,7 +136,7 @@ end
 module Package_summary = struct
   type t = {
     name : OpamPackage.Name.t;
-    version : string;
+    version : OpamPackage.Version.t;
     url_src : Url.t option;
     hashes : OpamHash.t list;
     dev_repo : string option;
@@ -143,7 +145,7 @@ module Package_summary = struct
 
   let equal { name; version; url_src; hashes; dev_repo; depexts } t' =
     OpamPackage.Name.equal name t'.name
-    && String.equal version t'.version
+    && OpamPackage.Version.equal version t'.version
     && Option.equal Url.equal url_src t'.url_src
     && List.equal Hash.equal hashes t'.hashes
     && Option.equal String.equal dev_repo t'.dev_repo
@@ -154,7 +156,7 @@ module Package_summary = struct
     Format.fprintf fmt
       "@[<hov 2>{ name = %a;@ version = %a;@ url_src = %a;@ hashes = %a;@ \
        dev_repo = %a;@ depexts = %a }@]"
-      Pp.package_name name string version
+      Pp.package_name name Pp.version version
       (option ~brackets:true Url.pp)
       url_src (list Hash.pp) hashes
       (option ~brackets:true string)
@@ -162,7 +164,7 @@ module Package_summary = struct
 
   let from_opam ~pkg opam_file =
     let name = OpamPackage.name pkg in
-    let version = OpamPackage.version_to_string pkg in
+    let version = OpamPackage.version pkg in
     let url_field = OpamFile.OPAM.url opam_file in
     let url_src = Option.map ~f:Url.from_opam_field url_field in
     let hashes =

--- a/lib/opam.mli
+++ b/lib/opam.mli
@@ -14,7 +14,7 @@ end
 
 module Package_summary : sig
   type t = {
-    name : string;
+    name : OpamPackage.Name.t;
     version : string;
     url_src : Url.t option;
     hashes : OpamHash.t list;

--- a/lib/opam.mli
+++ b/lib/opam.mli
@@ -15,7 +15,7 @@ end
 module Package_summary : sig
   type t = {
     name : OpamPackage.Name.t;
-    version : string;
+    version : OpamPackage.Version.t;
     url_src : Url.t option;
     hashes : OpamHash.t list;
     dev_repo : string option;
@@ -42,6 +42,8 @@ module Pp : sig
   val package : OpamPackage.t Fmt.t
 
   val package_name : OpamPackage.Name.t Fmt.t
+
+  val version : OpamPackage.Version.t Fmt.t
 
   val hash : OpamHash.t Fmt.t
 

--- a/lib/opam.mli
+++ b/lib/opam.mli
@@ -40,6 +40,8 @@ end
 module Pp : sig
   val package : OpamPackage.t Fmt.t
 
+  val raw_package : OpamPackage.t Fmt.t
+
   val package_name : OpamPackage.Name.t Fmt.t
 
   val version : OpamPackage.Version.t Fmt.t

--- a/lib/opam.mli
+++ b/lib/opam.mli
@@ -14,8 +14,7 @@ end
 
 module Package_summary : sig
   type t = {
-    name : OpamPackage.Name.t;
-    version : OpamPackage.Version.t;
+    package : OpamPackage.t;
     url_src : Url.t option;
     hashes : OpamHash.t list;
     dev_repo : string option;

--- a/test/lib/test_duniverse.ml
+++ b/test/lib/test_duniverse.ml
@@ -17,7 +17,7 @@ module Testable = struct
   end
 end
 
-let summary_factory ?(name = "") ?(version = "") ?dev_repo ?url_src
+let summary_factory ?(name = "undefined") ?(version = "1") ?dev_repo ?url_src
     ?(hashes = []) ?(depexts = []) () =
   let name = OpamPackage.Name.of_string name in
   let version = OpamPackage.Version.of_string version in

--- a/test/lib/test_duniverse.ml
+++ b/test/lib/test_duniverse.ml
@@ -20,7 +20,13 @@ end
 let summary_factory ?(name = "") ?(version = "") ?dev_repo ?url_src
     ?(hashes = []) ?(depexts = []) () =
   let name = OpamPackage.Name.of_string name in
+  let version = OpamPackage.Version.of_string version in
   { Opam.Package_summary.name; version; dev_repo; url_src; hashes; depexts }
+
+let opam_factory ~name ~version =
+  let name = OpamPackage.Name.of_string name in
+  let version = OpamPackage.Version.of_string version in
+  Duniverse.Opam.{ name; version }
 
 module Repo = struct
   module Package = struct
@@ -57,8 +63,7 @@ module Repo = struct
             (Ok
                (Some
                   {
-                    opam =
-                      { name = OpamPackage.Name.of_string "y"; version = "v" };
+                    opam = opam_factory ~name:"y" ~version:"v";
                     dev_repo = "d";
                     url = Other "u";
                     hashes = [];
@@ -75,8 +80,7 @@ module Repo = struct
             (Ok
                (Some
                   {
-                    opam =
-                      { name = OpamPackage.Name.of_string "y"; version = "v" };
+                    opam = opam_factory ~name:"y" ~version:"v";
                     dev_repo = "d";
                     url = Git { repo = "r"; ref = "master" };
                     hashes = [];
@@ -88,8 +92,8 @@ module Repo = struct
   let package_factory ?(name = "") ?(version = "") ?(dev_repo = "")
       ?(url = Duniverse.Repo.Url.Other "") ?(hashes = []) () =
     let open Duniverse.Repo.Package in
-    let name = OpamPackage.Name.of_string name in
-    { opam = { name; version }; dev_repo; url; hashes }
+    let opam = opam_factory ~name ~version in
+    { opam; dev_repo; url; hashes }
 
   let test_from_packages =
     let make_test ~name ~dev_repo ~packages ~expected () =
@@ -115,8 +119,7 @@ module Repo = struct
             dir = "d";
             url = Other "u";
             hashes = [];
-            provided_packages =
-              [ { name = OpamPackage.Name.of_string "p"; version = "v" } ];
+            provided_packages = [ opam_factory ~name:"p" ~version:"v" ];
           }
         ();
       make_test ~name:"Uses repository name as dir"
@@ -131,8 +134,7 @@ module Repo = struct
             dir = "repo";
             url = Other "u";
             hashes = [];
-            provided_packages =
-              [ { name = OpamPackage.Name.of_string "p"; version = "v" } ];
+            provided_packages = [ opam_factory ~name:"p" ~version:"v" ];
           }
         ();
       make_test ~name:"Expection for dune"
@@ -147,8 +149,7 @@ module Repo = struct
             dir = "dune_";
             url = Other "u";
             hashes = [];
-            provided_packages =
-              [ { name = OpamPackage.Name.of_string "p"; version = "v" } ];
+            provided_packages = [ opam_factory ~name:"p" ~version:"v" ];
           }
         ();
       make_test ~name:"Add all to provided packages" ~dev_repo:"d"
@@ -166,8 +167,8 @@ module Repo = struct
             hashes = [];
             provided_packages =
               [
-                { name = OpamPackage.Name.of_string "d"; version = "zdev" };
-                { name = OpamPackage.Name.of_string "d-lwt"; version = "zdev" };
+                opam_factory ~name:"d" ~version:"zdev";
+                opam_factory ~name:"d-lwt" ~version:"zdev";
               ];
           }
         ();
@@ -186,8 +187,8 @@ module Repo = struct
             hashes = [];
             provided_packages =
               [
-                { name = OpamPackage.Name.of_string "d"; version = "1" };
-                { name = OpamPackage.Name.of_string "d-lwt"; version = "2" };
+                opam_factory ~name:"d" ~version:"1";
+                opam_factory ~name:"d-lwt" ~version:"2";
               ];
           }
         ();
@@ -230,8 +231,7 @@ let test_from_package_summaries =
                dir = "d";
                url = Other "u";
                hashes = [];
-               provided_packages =
-                 [ { name = OpamPackage.Name.of_string "x"; version = "v" } ];
+               provided_packages = [ opam_factory ~name:"x" ~version:"v" ];
              };
            ])
       ();
@@ -252,8 +252,8 @@ let test_from_package_summaries =
                hashes = [];
                provided_packages =
                  [
-                   { name = OpamPackage.Name.of_string "y-lwt"; version = "v" };
-                   { name = OpamPackage.Name.of_string "y"; version = "v" };
+                   opam_factory ~name:"y-lwt" ~version:"v";
+                   opam_factory ~name:"y" ~version:"v";
                  ];
              };
            ])

--- a/test/lib/test_duniverse.ml
+++ b/test/lib/test_duniverse.ml
@@ -17,16 +17,15 @@ module Testable = struct
   end
 end
 
-let summary_factory ?(name = "undefined") ?(version = "1") ?dev_repo ?url_src
-    ?(hashes = []) ?(depexts = []) () =
-  let name = OpamPackage.Name.of_string name in
-  let version = OpamPackage.Version.of_string version in
-  { Opam.Package_summary.name; version; dev_repo; url_src; hashes; depexts }
-
 let opam_factory ~name ~version =
   let name = OpamPackage.Name.of_string name in
   let version = OpamPackage.Version.of_string version in
-  Duniverse.Opam.{ name; version }
+  OpamPackage.create name version
+
+let summary_factory ?(name = "undefined") ?(version = "1") ?dev_repo ?url_src
+    ?(hashes = []) ?(depexts = []) () =
+  let package = opam_factory ~name ~version in
+  { Opam.Package_summary.package; dev_repo; url_src; hashes; depexts }
 
 module Repo = struct
   module Package = struct

--- a/test/lib/test_duniverse.ml
+++ b/test/lib/test_duniverse.ml
@@ -19,6 +19,7 @@ end
 
 let summary_factory ?(name = "") ?(version = "") ?dev_repo ?url_src
     ?(hashes = []) ?(depexts = []) () =
+  let name = OpamPackage.Name.of_string name in
   { Opam.Package_summary.name; version; dev_repo; url_src; hashes; depexts }
 
 module Repo = struct
@@ -56,7 +57,8 @@ module Repo = struct
             (Ok
                (Some
                   {
-                    opam = { name = "y"; version = "v" };
+                    opam =
+                      { name = OpamPackage.Name.of_string "y"; version = "v" };
                     dev_repo = "d";
                     url = Other "u";
                     hashes = [];
@@ -73,7 +75,8 @@ module Repo = struct
             (Ok
                (Some
                   {
-                    opam = { name = "y"; version = "v" };
+                    opam =
+                      { name = OpamPackage.Name.of_string "y"; version = "v" };
                     dev_repo = "d";
                     url = Git { repo = "r"; ref = "master" };
                     hashes = [];
@@ -85,6 +88,7 @@ module Repo = struct
   let package_factory ?(name = "") ?(version = "") ?(dev_repo = "")
       ?(url = Duniverse.Repo.Url.Other "") ?(hashes = []) () =
     let open Duniverse.Repo.Package in
+    let name = OpamPackage.Name.of_string name in
     { opam = { name; version }; dev_repo; url; hashes }
 
   let test_from_packages =
@@ -111,7 +115,8 @@ module Repo = struct
             dir = "d";
             url = Other "u";
             hashes = [];
-            provided_packages = [ { name = "p"; version = "v" } ];
+            provided_packages =
+              [ { name = OpamPackage.Name.of_string "p"; version = "v" } ];
           }
         ();
       make_test ~name:"Uses repository name as dir"
@@ -126,7 +131,8 @@ module Repo = struct
             dir = "repo";
             url = Other "u";
             hashes = [];
-            provided_packages = [ { name = "p"; version = "v" } ];
+            provided_packages =
+              [ { name = OpamPackage.Name.of_string "p"; version = "v" } ];
           }
         ();
       make_test ~name:"Expection for dune"
@@ -141,7 +147,8 @@ module Repo = struct
             dir = "dune_";
             url = Other "u";
             hashes = [];
-            provided_packages = [ { name = "p"; version = "v" } ];
+            provided_packages =
+              [ { name = OpamPackage.Name.of_string "p"; version = "v" } ];
           }
         ();
       make_test ~name:"Add all to provided packages" ~dev_repo:"d"
@@ -159,8 +166,8 @@ module Repo = struct
             hashes = [];
             provided_packages =
               [
-                { name = "d"; version = "zdev" };
-                { name = "d-lwt"; version = "zdev" };
+                { name = OpamPackage.Name.of_string "d"; version = "zdev" };
+                { name = OpamPackage.Name.of_string "d-lwt"; version = "zdev" };
               ];
           }
         ();
@@ -179,7 +186,8 @@ module Repo = struct
             hashes = [];
             provided_packages =
               [
-                { name = "d"; version = "1" }; { name = "d-lwt"; version = "2" };
+                { name = OpamPackage.Name.of_string "d"; version = "1" };
+                { name = OpamPackage.Name.of_string "d-lwt"; version = "2" };
               ];
           }
         ();
@@ -222,7 +230,8 @@ let test_from_package_summaries =
                dir = "d";
                url = Other "u";
                hashes = [];
-               provided_packages = [ { name = "x"; version = "v" } ];
+               provided_packages =
+                 [ { name = OpamPackage.Name.of_string "x"; version = "v" } ];
              };
            ])
       ();
@@ -243,8 +252,8 @@ let test_from_package_summaries =
                hashes = [];
                provided_packages =
                  [
-                   { name = "y-lwt"; version = "v" };
-                   { name = "y"; version = "v" };
+                   { name = OpamPackage.Name.of_string "y-lwt"; version = "v" };
+                   { name = OpamPackage.Name.of_string "y"; version = "v" };
                  ];
              };
            ])


### PR DESCRIPTION
This is a prerequisite PR to the hybrid mode, it sets the `vendor` variable on all packages that we intend to vendor.

I tried running it on `opam-monorepo` and while there is a denylist of packages in `Config.base_packages` it seems to still want to pull packages like `ocaml-config`. I wonder if this is correct or whether we'd need to add more exceptions to it (like when the package version is `"base"` for example).