### PR TITLE
Convert usage of `>>=` into let-syntax

### DIFF
--- a/cli/common.ml
+++ b/cli/common.ml
@@ -123,7 +123,8 @@ let find_lockfile_aux ~explicit_lockfile repo =
   match explicit_lockfile with
   | Some file -> Ok file
   | None -> (
-      Project.local_lockfiles repo >>= function
+      let* local_lockfiles = Project.local_lockfiles repo in
+      match local_lockfiles with
       | [] ->
           Rresult.R.error_msg
             "No lockfile: try running `opam monorepo lock` first"

--- a/cli/depext.ml
+++ b/cli/depext.ml
@@ -14,7 +14,7 @@ let should_install ~yes pkgs =
 
 let run (`Root root) (`Lockfile explicit_lockfile) dry_run (`Yes yes) () =
   let open Result.O in
-  Common.find_lockfile ~explicit_lockfile root >>= fun lockfile ->
+  let* lockfile = Common.find_lockfile ~explicit_lockfile root in
   let depexts = Lockfile.depexts lockfile in
   OpamGlobalState.with_ `Lock_none (fun global_state ->
       let env = OpamPackageVar.resolve_global global_state in

--- a/cli/list_cmd.ml
+++ b/cli/list_cmd.ml
@@ -80,8 +80,8 @@ let with_descr pkgs =
 
 let run (`Root root) (`Lockfile explicit_lockfile) short () =
   let open Result.O in
-  Common.find_lockfile ~explicit_lockfile ~quiet:short root >>= fun lockfile ->
-  Lockfile.to_duniverse lockfile >>| fun duniverse ->
+  let* lockfile = Common.find_lockfile ~explicit_lockfile ~quiet:short root in
+  let+ duniverse = Lockfile.to_duniverse lockfile in
   let pkgs = pkgs_of_duniverse duniverse in
   let pkgs = with_descr pkgs in
   let max_name, max_version =

--- a/lib/git.ml
+++ b/lib/git.ml
@@ -52,8 +52,7 @@ module Ls_remote = struct
     | [ "" ] when looks_like_commit ref -> log_approx ()
     | [ "" ] -> Error `No_such_ref
     | _ -> (
-        Result.List.map ~f:parse_output_line output_lines
-        >>= fun parsed_lines ->
+        let* parsed_lines = Result.List.map ~f:parse_output_line output_lines in
         let search prefix =
           let result = search_ref (prefix ^ ref) parsed_lines in
           interpret_search_result result

--- a/lib/lockfile.ml
+++ b/lib/lockfile.ml
@@ -272,7 +272,7 @@ module Duniverse_dirs = struct
            };
        _;
       } ->
-          Result.List.map ~f:hash_from_opam_value hashes >>= fun hashes ->
+          let* hashes = Result.List.map ~f:hash_from_opam_value hashes in
           Ok (OpamUrl.of_string url, (dir, hashes))
       | _ ->
           value_errorf ~value
@@ -280,7 +280,7 @@ module Duniverse_dirs = struct
     in
     match value with
     | { pelem = List { pelem = l; _ }; _ } ->
-        Result.List.map ~f:elm_from_opam_value l >>= fun bindings ->
+        let* bindings = Result.List.map ~f:elm_from_opam_value l in
         Ok (OpamUrl.Map.of_list bindings)
     | _ -> value_errorf ~value "Expected a list"
 
@@ -367,7 +367,7 @@ let to_duniverse { duniverse_dirs; pin_depends; _ } =
           in
           Error (`Msg msg)
       | Some (dir, hashes) ->
-          url_to_duniverse_url url >>= fun url ->
+          let* url = url_to_duniverse_url url in
           Ok { Duniverse.Repo.dir; url; hashes; provided_packages })
 
 let to_opam (t : t) =
@@ -384,31 +384,35 @@ let to_opam (t : t) =
 
 let from_opam ?file opam =
   let open Result.O in
-  Extra_field.get ?file Version.field opam >>= fun version ->
-  Version.compatible version >>= fun () ->
-  Extra_field.get ?file Root_packages.field opam >>= fun root_packages ->
-  Depends.from_filtered_formula (OpamFile.OPAM.depends opam) >>= fun depends ->
+  let* version = Extra_field.get ?file Version.field opam in
+  let* () = Version.compatible version in
+  let* root_packages = Extra_field.get ?file Root_packages.field opam in
+  let* depends = Depends.from_filtered_formula (OpamFile.OPAM.depends opam) in
   let pin_depends = OpamFile.OPAM.pin_depends opam in
-  Extra_field.get ?file Duniverse_dirs.field opam >>= fun duniverse_dirs ->
+  let* duniverse_dirs = Extra_field.get ?file Duniverse_dirs.field opam in
   let depexts = OpamFile.OPAM.depexts opam in
   Ok { version; root_packages; depends; pin_depends; duniverse_dirs; depexts }
 
 let save ~file t =
   let open Result.O in
   let opam = to_opam t in
-  Bos.OS.File.with_oc file
-    (fun oc () ->
-      OpamFile.OPAM.write_to_channel oc opam;
-      Ok ())
-    ()
-  >>= fun res -> res
+  let* res =
+    Bos.OS.File.with_oc file
+      (fun oc () ->
+        OpamFile.OPAM.write_to_channel oc opam;
+        Ok ())
+      ()
+  in
+  res
 
 let load ~file =
   let open Result.O in
   let filename = Fpath.to_string file in
-  Bos.OS.File.with_ic file
-    (fun ic () ->
-      let filename = OpamFile.make (OpamFilename.of_string filename) in
-      OpamFile.OPAM.read_from_channel ~filename ic)
-    ()
-  >>= fun opam -> from_opam ~file:filename opam
+  let* opam =
+    Bos.OS.File.with_ic file
+      (fun ic () ->
+        let filename = OpamFile.make (OpamFilename.of_string filename) in
+        OpamFile.OPAM.read_from_channel ~filename ic)
+      ()
+  in
+  from_opam ~file:filename opam

--- a/lib/lockfile.ml
+++ b/lib/lockfile.ml
@@ -394,16 +394,13 @@ let from_opam ?file opam =
   Ok { version; root_packages; depends; pin_depends; duniverse_dirs; depexts }
 
 let save ~file t =
-  let open Result.O in
   let opam = to_opam t in
-  let* res =
-    Bos.OS.File.with_oc file
-      (fun oc () ->
-        OpamFile.OPAM.write_to_channel oc opam;
-        Ok ())
-      ()
-  in
-  res
+  Bos.OS.File.with_oc file
+    (fun oc () ->
+      OpamFile.OPAM.write_to_channel oc opam;
+      Ok ())
+    ()
+  |> Result.join
 
 let load ~file =
   let open Result.O in

--- a/lib/opam_solve.ml
+++ b/lib/opam_solve.ml
@@ -123,13 +123,13 @@ let fixed_packages ~local_packages ~pin_depends =
 
 let calculate_raw ~build_only ~allow_jbuilder ~ocaml_version ~local_packages
     ~target_packages ~pin_depends switch_state =
-  let open Rresult.R.Infix in
+  let open Result.O in
   let target_packages_names = OpamPackage.Name.Set.elements target_packages in
   let install_test_deps_for =
     if build_only then OpamPackage.Name.Set.empty else target_packages
   in
   let constraints = constraints ~ocaml_version in
-  fixed_packages ~local_packages ~pin_depends >>= fun fixed_packages ->
+  let* fixed_packages = fixed_packages ~local_packages ~pin_depends in
   let context =
     Switch_and_local_packages_context.create ~install_test_deps_for
       ~allow_jbuilder ~constraints ~fixed_packages switch_state
@@ -194,10 +194,12 @@ let get_opam_info ~pin_depends ~switch_state pkg =
 
 let calculate ~build_only ~allow_jbuilder ~local_opam_files ~target_packages
     ~pin_depends ?ocaml_version switch_state =
-  let open Rresult.R.Infix in
-  calculate_raw ~build_only ~allow_jbuilder ~ocaml_version
-    ~local_packages:local_opam_files ~target_packages ~pin_depends switch_state
-  >>= fun deps ->
+  let open Result.O in
+  let* deps =
+    calculate_raw ~build_only ~allow_jbuilder ~ocaml_version
+      ~local_packages:local_opam_files ~target_packages ~pin_depends
+      switch_state
+  in
   Logs.app (fun l ->
       l "%aFound %a opam dependencies for the target package%a."
         Pp.Styled.header ()

--- a/lib/persist.ml
+++ b/lib/persist.ml
@@ -15,14 +15,15 @@
  *)
 
 open Bos
-open Rresult
+open Import
+open Result.O
 
 let load_sexp label conv file =
   Logs.debug (fun l -> l "Reading file %a for %s" Fpath.pp file label);
-  OS.File.read file >>= fun b ->
-  try Sexplib.Sexp.of_string b |> conv |> R.ok
+  let* b = OS.File.read file in
+  try Sexplib.Sexp.of_string b |> conv |> Result.ok
   with exn ->
-    R.error_msg
+    Rresult.R.error_msg
       (Fmt.str "Error parsing %a: %s" Fpath.pp file (Printexc.to_string exn))
 
 let save_sexp label conv file v =

--- a/lib/pin_depends.ml
+++ b/lib/pin_depends.ml
@@ -25,8 +25,10 @@ let sort_uniq pin_depends =
           (OpamPackage.to_string pkg')
           (OpamUrl.to_string url')
   in
-  Result.List.fold_left ~init:OpamPackage.Name.Map.empty ~f:add pin_depends
-  >>| fun map -> OpamPackage.Name.Map.values map
+  let+ map =
+    Result.List.fold_left ~init:OpamPackage.Name.Map.empty ~f:add pin_depends
+  in
+  OpamPackage.Name.Map.values map
 
 let group_by_url t_list =
   List.fold_left

--- a/lib/uri_utils.ml
+++ b/lib/uri_utils.ml
@@ -1,7 +1,9 @@
+open Import
+
 let has_git_extension uri =
-  let open Rresult.R.Infix in
+  let open Result.O in
   let ext_res =
-    Fpath.of_string (Uri.path uri) >>| fun path ->
+    let+ path = Fpath.of_string (Uri.path uri) in
     Fpath.get_ext ~multi:true path
   in
   match ext_res with Ok ".git" -> true | Ok _ | Error _ -> false

--- a/stdext/result.ml
+++ b/stdext/result.ml
@@ -8,6 +8,10 @@ module O = struct
   let ( >>= ) res f = bind ~f res
 
   let ( >>| ) res f = map ~f res
+
+  let ( let* ) = ( >>= )
+
+  let ( let+ ) = ( >>| )
 end
 
 let map_error ~f = function Ok x -> Ok x | Error e -> Error (f e)
@@ -27,17 +31,25 @@ module List = struct
     aux [] l
 
   let rec iter ~f l =
-    match l with [] -> Ok () | hd :: tl -> f hd >>= fun () -> iter ~f tl
+    match l with
+    | [] -> Ok ()
+    | hd :: tl ->
+        let* () = f hd in
+        iter ~f tl
 
   let all =
     let rec loop acc = function
       | [] -> Ok (List.rev acc)
-      | t :: l -> t >>= fun x -> loop (x :: acc) l
+      | t :: l ->
+          let* x = t in
+          loop (x :: acc) l
     in
     fun l -> loop [] l
 
   let rec fold_left t ~f ~init =
     match t with
     | [] -> Ok init
-    | x :: xs -> f init x >>= fun init -> fold_left xs ~f ~init
+    | x :: xs ->
+        let* init = f init x in
+        fold_left xs ~f ~init
 end

--- a/stdext/result.mli
+++ b/stdext/result.mli
@@ -10,6 +10,10 @@ module O : sig
   val ( >>= ) : ('a, 'err) t -> ('a -> ('b, 'err) t) -> ('b, 'err) t
 
   val ( >>| ) : ('a, 'err) t -> ('a -> 'b) -> ('b, 'err) t
+
+  val ( let* ) : ('a, 'err) t -> ('a -> ('b, 'err) t) -> ('b, 'err) t
+
+  val ( let+ ) : ('a, 'err) t -> ('a -> 'b) -> ('b, 'err) t
 end
 
 val map_error : f:('a -> 'b) -> ('ok, 'a) t -> ('ok, 'b) t


### PR DESCRIPTION
We are depending on OCaml 4.08 which supports this syntax already and it makes things a bit easier to read because it is closer to direct style and avoids a little bit of boilerplate. I have used `ppx_let` in the past and it was quite convenient when working with a lot of `result` or `Deferred.t` to just bind them as if they were values.

Only shame about missing `match*` which required binding and matching in some few cases.