### PR TITLE
Move Extra_field out of Lockfile

### DIFF
--- a/lib/opam.ml
+++ b/lib/opam.ml
@@ -194,3 +194,25 @@ let local_package_version opam_file ~explicit_version =
   | None ->
       let default = OpamPackage.Version.of_string "zdev" in
       Option.value (OpamFile.OPAM.version_opt opam_file) ~default
+
+module Extra_field = struct
+  type 'a t = {
+    name : string;
+    to_opam_value : 'a -> OpamParserTypes.FullPos.value;
+    from_opam_value :
+      OpamParserTypes.FullPos.value -> ('a, [ `Msg of string ]) result;
+  }
+
+  let make ~name ~to_opam_value ~from_opam_value =
+    {
+      name = Printf.sprintf "x-opam-monorepo-%s" name;
+      to_opam_value;
+      from_opam_value;
+    }
+
+  let name t = t.name
+
+  let set t a opam = OpamFile.OPAM.add_extension opam t.name (t.to_opam_value a)
+
+  let get t opam = OpamFile.OPAM.extended opam t.name t.from_opam_value
+end

--- a/lib/opam.mli
+++ b/lib/opam.mli
@@ -51,6 +51,35 @@ module Pp : sig
   val url : OpamUrl.t Fmt.t
 end
 
+module Extra_field : sig
+  (** Module for parsing and printing of opam file extensions
+      specific to opam-monorepo *)
+
+  type 'a t
+  (** Type of extra opam field holding values of type ['a]. *)
+
+  val make :
+    name:string ->
+    to_opam_value:('a -> OpamParserTypes.FullPos.value) ->
+    from_opam_value:
+      (OpamParserTypes.FullPos.value -> ('a, [ `Msg of string ]) result) ->
+    'a t
+  (** [make ~name ~to_opam_value ~from_opam_value] returns an extra field
+      which is named ["x-opam-monorepo-<name>"] and that is converted to and
+      from generic opam values using the provided functions. *)
+
+  val name : _ t -> string
+  (** Return the full name of the field *)
+
+  val set : 'a t -> 'a -> OpamFile.OPAM.t -> OpamFile.OPAM.t
+  (** Sets the field in the given opam file, potentially overwriting the
+      previous value. *)
+
+  val get : 'a t -> OpamFile.OPAM.t -> ('a, [ `Msg of string ]) result option
+  (** Returns the optional value of the given extra field in the given opam
+      file. *)
+end
+
 val depends_on_dune : allow_jbuilder:bool -> OpamTypes.filtered_formula -> bool
 (** Returns whether the given depends field formula contains a dependency to dune or jbuilder *)
 

--- a/lib/opam.mli
+++ b/lib/opam.mli
@@ -76,8 +76,8 @@ module Extra_field : sig
       previous value. *)
 
   val get : 'a t -> OpamFile.OPAM.t -> ('a, [ `Msg of string ]) result option
-  (** Returns the optional value of the given extra field in the given opam
-      file. *)
+  (** Returns the value of the given extra field in the given opam file if
+      the extra field is set. *)
 end
 
 val depends_on_dune : allow_jbuilder:bool -> OpamTypes.filtered_formula -> bool


### PR DESCRIPTION
This is strictly a refactoring and a small one but it was necessary for the work I am currently doing on reproducible `lock` and thought it might also be of use for #234!

This should make rebasing either of these features easier along with reducing the size of the PRs so it seemed worthwile to extract it to its own PR.