### PR TITLE
Add doc to opam file and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 with your projects and all of their dependencies, letting you build it all from scratch
 using only `dune` and `ocaml`.
 
-Online documentation is available [here](https://ocamllabs.io/opam-monorepo/opam-monorepo/index.html).
+[Documentation on opam-monorepo](https://ocamllabs.io/opam-monorepo/opam-monorepo/index.html) is available in the repository as well as available online.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
-[![Build Status](https://img.shields.io/endpoint?url=https%3A%2F%2Fci.ocamllabs.io%2Fbadge%2Focamllabs%2Fopam-monorepo%2Fmain&logo=ocaml)](https://ci.ocamllabs.io/github/ocamllabs/opam-monorepo)
+[![Build Status](https://img.shields.io/endpoint?url=https%3A%2F%2Fci.ocamllabs.io%2Fbadge%2Focamllabs%2Fopam-monorepo%2Fmain&logo=ocaml)](https://ci.ocamllabs.io/github/ocamllabs/opam-monorepo) [![Documentation](https://img.shields.io/badge/doc-online-blue)](https://ocamllabs.io/opam-monorepo/opam-monorepo/index.html)
 
 # opam-monorepo
 
 `opam-monorepo` is an opam plugin designed to assemble standalone dune workspaces
 with your projects and all of their dependencies, letting you build it all from scratch
 using only `dune` and `ocaml`.
+
+Online documentation is available [here](https://ocamllabs.io/opam-monorepo/opam-monorepo/index.html).
 
 ## Installation
 

--- a/dune-project
+++ b/dune-project
@@ -8,6 +8,7 @@
 (license ISC)
 (authors "Anil Madhavapeddy" "Nathan Rebours" "Lucas Pluvinage" "Jules Aguillon")
 (maintainers "anil@recoil.org")
+(documentation "https://ocamllabs.github.io/opam-monorepo")
 
 (package
  (name opam-monorepo)

--- a/opam-monorepo.opam
+++ b/opam-monorepo.opam
@@ -11,6 +11,7 @@ authors: [
 ]
 license: "ISC"
 homepage: "https://github.com/ocamllabs/opam-monorepo"
+doc: "https://ocamllabs.github.io/opam-monorepo"
 bug-reports: "https://github.com/ocamllabs/opam-monorepo/issues"
 depends: [
   "dune" {>= "2.7"}


### PR DESCRIPTION
I just published the doc generated from our `.mld` manual to our gh-pages using dune-release. I also added a couple of reference links in the README to make it easier to find.