### PR TITLE
Only find candidates that can't be built if there is no solution

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,11 @@
 
 ### Fixed
 
+- Only show an error that there are no packages that build with dune when there
+  is no solution. The code would otherwise report an that no packages build
+  with dune if the selected package builds with dune, leading to confusion.
+  (#245, @Leonidas-from-XIV)
+
 ### Removed
 
 ### Security

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,10 +13,8 @@
 
 ### Fixed
 
-- Only show an error that there are no packages that build with dune when there
-  is no solution. The code would otherwise report an that no packages build
-  with dune if the selected package builds with dune, leading to confusion.
-  (#245, @Leonidas-from-XIV)
+- Fix a bug where a package which had a single version that built with dune and got selected by the solver
+  would be reported has having no version building with dune. (#245, @Leonidas-from-XIV)
 
 ### Removed
 

--- a/lib/opam_solve.ml
+++ b/lib/opam_solve.ml
@@ -176,9 +176,12 @@ let not_buildable_with_dune diagnostics =
   let rolemap = Local_solver.diagnostics_rolemap diagnostics in
   Pkg_map.fold
     (fun pkg component acc ->
-      match no_version_builds_with_dune component with
-      | false -> acc
-      | true -> pkg :: acc)
+      match Local_solver.Diagnostics.Component.selected_impl component with
+      | Some _ -> acc
+      | None -> (
+          match no_version_builds_with_dune component with
+          | false -> acc
+          | true -> pkg :: acc))
     rolemap []
   |> List.filter_map ~f:Local_solver.package_name
 


### PR DESCRIPTION
We found this issue while pairing.

We should only look at rejected solutions when there is no selected solution. In a scenario where there is 1 selected candidate that builds with dune and all others don't build with dune this would produce a wrong error.