### PR TITLE
Use `Stdlib.Result` implementations

### DIFF
--- a/stdext/result.ml
+++ b/stdext/result.ml
@@ -1,8 +1,8 @@
 include Stdlib.Result
 
-let bind ~f = function Error _ as err -> err | Ok x -> f x
+let bind ~f r = bind r f
 
-let map ~f = function Error _ as err -> err | Ok x -> Ok (f x)
+let map ~f = map f
 
 module O = struct
   let ( >>= ) res f = bind ~f res
@@ -14,7 +14,7 @@ module O = struct
   let ( let+ ) = ( >>| )
 end
 
-let map_error ~f = function Ok x -> Ok x | Error e -> Error (f e)
+let map_error ~f = map_error f
 
 module List = struct
   open O


### PR DESCRIPTION
Since our minimum version is 4.08 and our module just adds labels to the functions (thus functioning like `ResultLabels` if that existed) it might be somewhat more elegant to just to defer to the built-in implementations.

This makes it a bit clearer that we're not doing anything different from the familiar `map`/`bind`/`map_error` implementations.