### PR TITLE
Better missing version error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,9 @@
 - Add opam extensions `x-opam-monorepo-opam-repositories` and
   `x-opam-monorepo-global-opam-vars` to make `lock` fully reproducible.
   (#250, #253, @NathanReb)
+- Show an error message when the solver can't find any version that satisfies
+  the requested version constraint in the user's OPAM file (#215, #248,
+  @Leonidas-from-XIV)
 
 ### Changed
 

--- a/cli/lock.ml
+++ b/cli/lock.ml
@@ -216,7 +216,7 @@ let could_not_determine_version offending_packages =
 let interpret_solver_error ~repositories solver = function
   | `Msg _ as err -> err
   | `Diagnostics d ->
-      (match Opam_solve.no_matching_versions solver d with
+      (match Opam_solve.unavailable_versions_due_to_constraints solver d with
       | [] -> ()
       | offending_packages -> could_not_determine_version offending_packages);
       (match Opam_solve.not_buildable_with_dune solver d with

--- a/cli/lock.ml
+++ b/cli/lock.ml
@@ -212,8 +212,7 @@ let could_not_determine_version offending_packages =
   let pp_offending_packages = Fmt.list ~sep:Fmt.comma pp_offending_package in
   Logs.err (fun l ->
       l
-        "There is no eligible package that matches %a. Make sure a dune port \
-         exists."
+        "There is no eligible package that matches %a."
         pp_offending_packages offending_packages)
 
 let interpret_solver_error ~repositories solver = function

--- a/cli/lock.ml
+++ b/cli/lock.ml
@@ -211,9 +211,8 @@ let could_not_determine_version offending_packages =
   in
   let pp_offending_packages = Fmt.list ~sep:Fmt.comma pp_offending_package in
   Logs.err (fun l ->
-      l
-        "There is no eligible package that matches %a."
-        pp_offending_packages offending_packages)
+      l "There is no eligible package that matches %a." pp_offending_packages
+        offending_packages)
 
 let interpret_solver_error ~repositories solver = function
   | `Msg _ as err -> err

--- a/cli/lock.ml
+++ b/cli/lock.ml
@@ -206,13 +206,12 @@ let could_not_determine_version offending_packages =
   in
   let s = OpamFormula.string_of_formula f in
   let pp_version_formula = Fmt.using s Fmt.string in
-  let pp_offending_package =
-    Fmt.pair ~sep:Fmt.sp Opam.Pp.package_name pp_version_formula
-  in
-  let pp_offending_packages = Fmt.list ~sep:Fmt.comma pp_offending_package in
-  Logs.err (fun l ->
-      l "There is no eligible package that matches %a." pp_offending_packages
-        offending_packages)
+  List.iter
+    ~f:(fun (name, formula) ->
+      Logs.err (fun l ->
+          l "There is no eligible version of %a that matches %a"
+            Opam.Pp.package_name name pp_version_formula formula))
+    offending_packages
 
 let interpret_solver_error ~repositories solver = function
   | `Msg _ as err -> err

--- a/cli/lock.ml
+++ b/cli/lock.ml
@@ -212,8 +212,8 @@ let could_not_determine_version offending_packages =
   let pp_offending_packages = Fmt.list ~sep:Fmt.comma pp_offending_package in
   Logs.err (fun l ->
       l
-        "Could not find any package that would satisfy the version constrants: \
-         %a"
+        "There is no eligible package that matches %a. Make sure a dune port \
+         exists."
         pp_offending_packages offending_packages)
 
 let interpret_solver_error ~repositories solver = function

--- a/lib/opam_solve.ml
+++ b/lib/opam_solve.ml
@@ -180,7 +180,7 @@ module type OPAM_MONOREPO_SOLVER = sig
 
   val not_buildable_with_dune : diagnostics -> OpamPackage.Name.t list
 
-  val no_matching_versions :
+  val unavailable_versions_due_to_constraints :
     diagnostics -> (OpamPackage.Name.t * OpamFormula.version_formula) list
 end
 
@@ -271,7 +271,7 @@ module Make_solver (Context : OPAM_MONOREPO_CONTEXT) :
     let _, version_restriction = Solver.formula restriction in
     Some version_restriction
 
-  let no_matching_versions diagnostics =
+  let unavailable_versions_due_to_constraints diagnostics =
     let rolemap = Solver.diagnostics_rolemap diagnostics in
     Pkg_map.fold
       (fun pkg component acc ->
@@ -487,7 +487,7 @@ let not_buildable_with_dune :
   in
   Solver.not_buildable_with_dune diagnostics
 
-let no_matching_versions :
+let unavailable_versions_due_to_constraints :
     type context diagnostics.
     (context, diagnostics) t ->
     diagnostics ->
@@ -498,4 +498,4 @@ let no_matching_versions :
          and type input = context) =
     t
   in
-  Solver.no_matching_versions diagnostics
+  Solver.unavailable_versions_due_to_constraints diagnostics

--- a/lib/opam_solve.ml
+++ b/lib/opam_solve.ml
@@ -280,30 +280,25 @@ module Make_solver (Context : OPAM_MONOREPO_CONTEXT) :
             let rejects, _reason =
               Solver.Diagnostics.Component.rejects component
             in
-            (* find only the model rejections that is those that we have rejected as e.g. not building with dune *)
-            let model_rejected =
-              List.filter_map
-                ~f:(fun (model, reason) ->
-                  match reason with
-                  | `Model_rejection _ -> Some model
-                  | _ -> None)
-                rejects
-            in
+            (* only looking at the model rejections that is those that we have rejected as e.g. not building with dune *)
             let model_rejections_would_match_version =
               List.exists
-                ~f:(fun model ->
-                  match Solver.version model with
-                  | None -> true
-                  | Some rejected_package ->
-                      let rejected_version =
-                        OpamPackage.version rejected_package
-                      in
-                      let would_be_eligible_otherwise =
-                        OpamFormula.check_version_formula version_restriction
-                          rejected_version
-                      in
-                      would_be_eligible_otherwise)
-                model_rejected
+                ~f:(fun (model, reason) ->
+                  match reason with
+                  | `Model_rejection _ -> (
+                      match Solver.version model with
+                      | None -> true
+                      | Some rejected_package ->
+                          let rejected_version =
+                            OpamPackage.version rejected_package
+                          in
+                          let would_be_eligible_otherwise =
+                            OpamFormula.check_version_formula
+                              version_restriction rejected_version
+                          in
+                          would_be_eligible_otherwise)
+                  | _ -> false)
+                rejects
             in
             let* failed_pkg =
               match model_rejections_would_match_version with

--- a/lib/opam_solve.ml
+++ b/lib/opam_solve.ml
@@ -266,19 +266,17 @@ module Make_solver (Context : OPAM_MONOREPO_CONTEXT) :
             let* pkg_name = Solver.package_name pkg in
             let notes = Solver.Diagnostics.Component.notes component in
             (* In the rejected candidates, try to find one where it had failed a version restriction and extract that one *)
-            let* version_restriction =
+            let* _, version_restriction =
               List.find_map
                 ~f:(function
+                  | UserRequested restriction -> Some restriction
                   | Restricts (_other_role, _impl, restrictions) -> (
                       match restrictions with
                       | [] -> None
-                      | restriction :: _ ->
-                          let _, version_restriction =
-                            Solver.formula restriction
-                          in
-                          Some version_restriction)
+                      | restriction :: _ -> Some restriction)
                   | _ -> None)
                 notes
+              |> Option.map ~f:Solver.formula
             in
             let rejects, _reason =
               Solver.Diagnostics.Component.rejects component

--- a/lib/opam_solve.ml
+++ b/lib/opam_solve.ml
@@ -305,7 +305,7 @@ module Make_solver (Context : OPAM_MONOREPO_CONTEXT) :
       (fun pkg component unavailable ->
         match Solver.Diagnostics.Component.selected_impl component with
         | Some _ -> unavailable
-        | None ->
+        | None -> (
             (* short-circuit skip of fold *)
             let ( let* ) a f =
               match a with Some a -> f a | None -> unavailable
@@ -324,12 +324,9 @@ module Make_solver (Context : OPAM_MONOREPO_CONTEXT) :
                 rejects
             in
             (* if it is unavailable, construct info on why *)
-            let* unavailable_pkg =
-              match model_rejections_would_match_version with
-              | false -> None
-              | true -> Some (pkg_name, version_restriction)
-            in
-            unavailable_pkg :: unavailable)
+            match model_rejections_would_match_version with
+            | false -> unavailable
+            | true -> (pkg_name, version_restriction) :: unavailable))
       rolemap []
 
   let get_opam_info ~context pkg =

--- a/lib/opam_solve.mli
+++ b/lib/opam_solve.mli
@@ -41,7 +41,7 @@ val diagnostics_message :
 val not_buildable_with_dune :
   (_, 'diagnostics) t -> 'diagnostics -> OpamPackage.Name.t list
 
-val no_matching_versions :
+val unavailable_versions_due_to_constraints :
   (_, 'diagnostics) t ->
   'diagnostics ->
   (OpamPackage.Name.t * OpamFormula.version_formula) list

--- a/lib/opam_solve.mli
+++ b/lib/opam_solve.mli
@@ -40,3 +40,8 @@ val diagnostics_message :
 
 val not_buildable_with_dune :
   (_, 'diagnostics) t -> 'diagnostics -> OpamPackage.Name.t list
+
+val no_matching_versions :
+  (_, 'diagnostics) t ->
+  'diagnostics ->
+  (OpamPackage.Name.t * OpamFormula.version_formula) list

--- a/stdext/option.ml
+++ b/stdext/option.ml
@@ -10,6 +10,10 @@ module O = struct
   let ( >>= ) opt f = bind ~f opt
 
   let ( >>| ) opt f = map ~f opt
+
+  let ( let* ) = ( >>= )
+
+  let ( let+ ) = ( >>| )
 end
 
 let map_default ~f ~default = function None -> default | Some x -> f x

--- a/stdext/option.mli
+++ b/stdext/option.mli
@@ -6,6 +6,10 @@ module O : sig
   val ( >>= ) : 'a t -> ('a -> 'b t) -> 'b t
 
   val ( >>| ) : 'a t -> ('a -> 'b) -> 'b t
+
+  val ( let* ) : 'a t -> ('a -> 'b t) -> 'b t
+
+  val ( let+ ) : 'a t -> ('a -> 'b) -> 'b t
 end
 
 val value : default:'a -> 'a t -> 'a

--- a/test/bin/invalid-package-version.t/existing.opam
+++ b/test/bin/invalid-package-version.t/existing.opam
@@ -1,0 +1,9 @@
+opam-version: "2.0"
+depends: [
+  "dune"
+  "a"
+]
+x-opam-monorepo-opam-repositories: [
+  "file://$OPAM_MONOREPO_CWD/minimal-repo"
+  "file://$OPAM_MONOREPO_CWD/repo"
+]

--- a/test/bin/invalid-package-version.t/multiple-constraint.opam
+++ b/test/bin/invalid-package-version.t/multiple-constraint.opam
@@ -1,7 +1,8 @@
 opam-version: "2.0"
 depends: [
   "dune"
-  "a" {>= "1.1" & < "2.0"}
+  "depends-on-min-a"
+  "a" {< "2.0"}
 ]
 x-opam-monorepo-opam-repositories: [
   "file://$OPAM_MONOREPO_CWD/minimal-repo"

--- a/test/bin/invalid-package-version.t/multiple-constraint.opam
+++ b/test/bin/invalid-package-version.t/multiple-constraint.opam
@@ -1,0 +1,9 @@
+opam-version: "2.0"
+depends: [
+  "dune"
+  "a" {>= "1.1" & < "2.0"}
+]
+x-opam-monorepo-opam-repositories: [
+  "file://$OPAM_MONOREPO_CWD/minimal-repo"
+  "file://$OPAM_MONOREPO_CWD/repo"
+]

--- a/test/bin/invalid-package-version.t/repo/packages/a/a.0.1/opam
+++ b/test/bin/invalid-package-version.t/repo/packages/a/a.0.1/opam
@@ -1,0 +1,11 @@
+opam-version: "2.0"
+dev-repo: "git+https://a.com/a.git"
+depends: [
+  "dune"
+]
+url {
+  src: "https://a.com/a.0.1.tbz"
+  checksum: [
+    "sha256=0000000000000000000000000000000000000000000000000000000000000000"
+  ]
+}

--- a/test/bin/invalid-package-version.t/repo/packages/a/a.1.0/opam
+++ b/test/bin/invalid-package-version.t/repo/packages/a/a.1.0/opam
@@ -1,0 +1,11 @@
+opam-version: "2.0"
+dev-repo: "git+https://a.com/a.git"
+depends: [
+  "ocaml"
+]
+url {
+  src: "https://a.com/a.1.0.tbz"
+  checksum: [
+    "sha256=0000000000000000000000000000000000000000000000000000000000000000"
+  ]
+}

--- a/test/bin/invalid-package-version.t/repo/packages/a/a.1.1/opam
+++ b/test/bin/invalid-package-version.t/repo/packages/a/a.1.1/opam
@@ -1,0 +1,11 @@
+opam-version: "2.0"
+dev-repo: "git+https://a.com/a.git"
+depends: [
+  "ocaml"
+]
+url {
+  src: "https://a.com/a.1.1.tbz"
+  checksum: [
+    "sha256=0000000000000000000000000000000000000000000000000000000000000000"
+  ]
+}

--- a/test/bin/invalid-package-version.t/repo/packages/depends-on-min-a/depends-on-min-a.1/opam
+++ b/test/bin/invalid-package-version.t/repo/packages/depends-on-min-a/depends-on-min-a.1/opam
@@ -1,0 +1,12 @@
+opam-version: "2.0"
+dev-repo: "git+https://a.com/depends-on-min-a.git"
+depends: [
+  "dune"
+  "a" {>= "1.0"}
+]
+url {
+  src: "https://a.com/depends-on-min-a.0.1.tbz"
+  checksum: [
+    "sha256=0000000000000000000000000000000000000000000000000000000000000000"
+  ]
+}

--- a/test/bin/invalid-package-version.t/repo/repo
+++ b/test/bin/invalid-package-version.t/repo/repo
@@ -1,0 +1,1 @@
+opam-version: "2.0"

--- a/test/bin/invalid-package-version.t/run.t
+++ b/test/bin/invalid-package-version.t/run.t
@@ -47,9 +47,9 @@ to the test)
 We should also produce the right error message with all the constraints when we have multiple constaints
 
   $ opam show --no-lint --raw -fdepends ./multiple-constraint.opam
-  "dune" "a" {>= "1.1" & < "2.0"}
+  "dune" "depends-on-min-a" "a" {< "2.0"}
   $ opam-monorepo lock multiple-constraint 2> errors
   ==> Using 1 locally scanned package as the target.
   [1]
   $ grep -Pazo "(?s)opam-monorepo: \[ERROR\].*(?=opam-monorepo)" < errors | head --bytes=-1
-  opam-monorepo: [ERROR] There is no eligible version of a that matches >= 1.1 & < 2.0
+  opam-monorepo: [ERROR] There is no eligible version of a that matches >= 1.0

--- a/test/bin/invalid-package-version.t/run.t
+++ b/test/bin/invalid-package-version.t/run.t
@@ -1,0 +1,41 @@
+We want to make sure the error messages are sensible, and as such if the user
+picks a version that doesn't exist we want to make them aware of it.
+
+We setup the default base repository
+
+  $ gen-minimal-repo
+
+Here we define a package test that depends on a package `a`:
+
+  $ grep '\"a\"' < existing.opam
+    "a"
+
+We have a local repo that defines a package `a` that satisfies the predicate,
+with a version that is valid and can be picked.
+
+  $ cat repo/packages/a/a.0.1/opam > /dev/null
+
+opam-monorepo solver should successfully pick a.0.1:
+
+  $ opam-monorepo lock existing
+  ==> Using 1 locally scanned package as the target.
+  ==> Found 9 opam dependencies for the target package.
+  ==> Querying opam database for their metadata and Dune compatibility.
+  ==> Calculating exact pins for each of them.
+  ==> Wrote lockfile with 1 entries to $TESTCASE_ROOT/existing.opam.locked. You can now run opam monorepo pull to fetch their sources.
+  $ cat existing.opam.locked | grep "\"a\"\s\+{"
+    "a" {= "0.1" & vendor}
+
+Yet if we attempt to use the same package, but pick a version that doesn't exist in our repo:
+
+  $ grep '\"a\"' < toonew.opam
+    "a" {>= "1.0"}
+
+opam-monorepo should display an error message that there is no version of `a` that matches the constraint.
+
+  $ opam-monorepo lock toonew 2> errors
+  ==> Using 1 locally scanned package as the target.
+  [1]
+  $ grep -Pzo "(?s)opam-monorepo: \[ERROR\].*(?=opam-monorepo)" < errors
+  opam-monorepo: [ERROR] There is no eligible package that matches a
+                         >= 1.0. Make sure a dune port exists.

--- a/test/bin/invalid-package-version.t/run.t
+++ b/test/bin/invalid-package-version.t/run.t
@@ -23,7 +23,7 @@ opam-monorepo solver should successfully pick a.0.1:
   ==> Querying opam database for their metadata and Dune compatibility.
   ==> Calculating exact pins for each of them.
   ==> Wrote lockfile with 1 entries to $TESTCASE_ROOT/existing.opam.locked. You can now run opam monorepo pull to fetch their sources.
-  $ cat existing.opam.locked | grep "\"a\"\s\+{"
+  $ grep "\"a\"\s\+{" existing.opam.locked 
     "a" {= "0.1" & vendor}
 
 Yet if we attempt to use the same package, but pick a version that doesn't

--- a/test/bin/invalid-package-version.t/run.t
+++ b/test/bin/invalid-package-version.t/run.t
@@ -43,3 +43,13 @@ to the test)
   [1]
   $ grep -Pazo "(?s)opam-monorepo: \[ERROR\].*(?=opam-monorepo)" < errors | head --bytes=-1
   opam-monorepo: [ERROR] There is no eligible version of a that matches >= 1.0
+
+We should also produce the right error message with all the constraints when we have multiple constaints
+
+  $ opam show --no-lint --raw -fdepends ./multiple-constraint.opam
+  "dune" "a" {>= "1.1" & < "2.0"}
+  $ opam-monorepo lock multiple-constraint 2> errors
+  ==> Using 1 locally scanned package as the target.
+  [1]
+  $ grep -Pazo "(?s)opam-monorepo: \[ERROR\].*(?=opam-monorepo)" < errors | head --bytes=-1
+  opam-monorepo: [ERROR] There is no eligible version of a that matches >= 1.1 & < 2.0

--- a/test/bin/invalid-package-version.t/run.t
+++ b/test/bin/invalid-package-version.t/run.t
@@ -26,16 +26,21 @@ opam-monorepo solver should successfully pick a.0.1:
   $ cat existing.opam.locked | grep "\"a\"\s\+{"
     "a" {= "0.1" & vendor}
 
-Yet if we attempt to use the same package, but pick a version that doesn't exist in our repo:
+Yet if we attempt to use the same package, but pick a version that doesn't
+exist in our repo:
 
   $ grep '\"a\"' < toonew.opam
     "a" {>= "1.0"}
 
-opam-monorepo should display an error message that there is no version of `a` that matches the constraint.
+opam-monorepo should fail with some error code and display an error message
+that there is no version of `a` that matches the constraint.
+
+(grep appends a NUL byte at the end, hence the head call, this is not important
+to the test)
 
   $ opam-monorepo lock toonew 2> errors
   ==> Using 1 locally scanned package as the target.
   [1]
-  $ grep -Pzo "(?s)opam-monorepo: \[ERROR\].*(?=opam-monorepo)" < errors
+  $ grep -Pazo "(?s)opam-monorepo: \[ERROR\].*(?=opam-monorepo)" < errors | head --bytes=-1
   opam-monorepo: [ERROR] There is no eligible package that matches a
                          >= 1.0. Make sure a dune port exists.

--- a/test/bin/invalid-package-version.t/run.t
+++ b/test/bin/invalid-package-version.t/run.t
@@ -7,8 +7,8 @@ We setup the default base repository
 
 Here we define a package test that depends on a package `a`:
 
-  $ grep '\"a\"' < existing.opam
-    "a"
+  $ opam show --no-lint --raw -fdepends ./existing.opam
+  "dune" "a"
 
 We have a local repo that defines a package `a` that satisfies the predicate,
 with a version that is valid and can be picked.
@@ -29,8 +29,8 @@ opam-monorepo solver should successfully pick a.0.1:
 Yet if we attempt to use the same package, but pick a version that doesn't
 exist in our repo:
 
-  $ grep '\"a\"' < toonew.opam
-    "a" {>= "1.0"}
+  $ opam show --no-lint --raw -fdepends ./toonew.opam
+  "dune" "a" {>= "1.0"}
 
 opam-monorepo should fail with some error code and display an error message
 that there is no version of `a` that matches the constraint.

--- a/test/bin/invalid-package-version.t/run.t
+++ b/test/bin/invalid-package-version.t/run.t
@@ -42,4 +42,4 @@ to the test)
   ==> Using 1 locally scanned package as the target.
   [1]
   $ grep -Pazo "(?s)opam-monorepo: \[ERROR\].*(?=opam-monorepo)" < errors | head --bytes=-1
-  opam-monorepo: [ERROR] There is no eligible package that matches a >= 1.0.
+  opam-monorepo: [ERROR] There is no eligible version of a that matches >= 1.0

--- a/test/bin/invalid-package-version.t/run.t
+++ b/test/bin/invalid-package-version.t/run.t
@@ -42,5 +42,4 @@ to the test)
   ==> Using 1 locally scanned package as the target.
   [1]
   $ grep -Pazo "(?s)opam-monorepo: \[ERROR\].*(?=opam-monorepo)" < errors | head --bytes=-1
-  opam-monorepo: [ERROR] There is no eligible package that matches a
-                         >= 1.0. Make sure a dune port exists.
+  opam-monorepo: [ERROR] There is no eligible package that matches a >= 1.0.

--- a/test/bin/invalid-package-version.t/toonew.opam
+++ b/test/bin/invalid-package-version.t/toonew.opam
@@ -1,0 +1,9 @@
+opam-version: "2.0"
+depends: [
+  "dune"
+  "a" {>= "1.0"}
+]
+x-opam-monorepo-opam-repositories: [
+  "file://$OPAM_MONOREPO_CWD/minimal-repo"
+  "file://$OPAM_MONOREPO_CWD/repo"
+]


### PR DESCRIPTION
I've continued to play around with what info can be retrieved from the map and with a bit of squinting (extracting the version restriction from another rejection case) I was able to test the version check on the packages that we exclude as not building with dune.

If I specify `fmt {>= "1.0.0"}` in my `opam` file I get this error message now:

```
opam-monorepo: [ERROR] Could not find any package that would satisfy the version constrants: fmt
                       >= 1.0.0
```

It is somewhat involved and hairy so I am not entirely sure whether this is worth it so I'm opening this PR as a draft, more of an RFC to see if we even want to do stuff this way or whether we should patch the 0install solver to expose better information instead.

Closes #215 