### PR TITLE
Fix explicit repo solver

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 - Add opam extensions `x-opam-monorepo-opam-repositories` and
   `x-opam-monorepo-global-opam-vars` to make `lock` fully reproducible.
-  (#250, @NathanReb)
+  (#250, #253, @NathanReb)
 
 ### Changed
 

--- a/lib/opam_solve.ml
+++ b/lib/opam_solve.ml
@@ -327,6 +327,7 @@ module Multi_dir_context :
                 Opam.Pp.package_name name Opam.Pp.version version);
           acc)
 
+  (** Candidates must be returned in decreasing preference order *)
   let candidates t name =
     let map =
       List.fold_left t ~init:OpamPackage.Version.Map.empty
@@ -334,7 +335,10 @@ module Multi_dir_context :
           let candidates = candidates dir_context name in
           merge_candidates ~name acc candidates)
     in
-    OpamPackage.Version.Map.bindings map
+    (* The bindings of the version map will be sorted by increasing version.
+       We reverse it so it's in decreasing version order for the solver to pick
+       the highest satisfying version. *)
+    List.rev (OpamPackage.Version.Map.bindings map)
 
   let user_restrictions t pkg = user_restrictions (List.hd t) pkg
 

--- a/test/bin/local-solver-picks-higher-version.t/repo/packages/a/a.0.1/opam
+++ b/test/bin/local-solver-picks-higher-version.t/repo/packages/a/a.0.1/opam
@@ -1,0 +1,11 @@
+opam-version: "2.0"
+dev-repo: "git+https://a.com/a.git"
+depends: [
+  "dune"
+]
+url {
+  src: "https://a.com/a.0.1.tbz"
+  checksum: [
+    "sha256=0000000000000000000000000000000000000000000000000000000000000000"
+  ]
+}

--- a/test/bin/local-solver-picks-higher-version.t/repo/packages/a/a.0.2/opam
+++ b/test/bin/local-solver-picks-higher-version.t/repo/packages/a/a.0.2/opam
@@ -1,0 +1,11 @@
+opam-version: "2.0"
+dev-repo: "git+https://a.com/a.git"
+depends: [
+  "dune"
+]
+url {
+  src: "https://a.com/a.0.2.tbz"
+  checksum: [
+    "sha256=0000000000000000000000000000000000000000000000000000000000000001"
+  ]
+}

--- a/test/bin/local-solver-picks-higher-version.t/repo/packages/base-bigarray/base-bigarray.base/opam
+++ b/test/bin/local-solver-picks-higher-version.t/repo/packages/base-bigarray/base-bigarray.base/opam
@@ -1,0 +1,6 @@
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+description: """
+Bigarray library distributed with the OCaml compiler
+"""
+

--- a/test/bin/local-solver-picks-higher-version.t/repo/packages/base-threads/base-threads.base/opam
+++ b/test/bin/local-solver-picks-higher-version.t/repo/packages/base-threads/base-threads.base/opam
@@ -1,0 +1,6 @@
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+description: """
+Threads library distributed with the OCaml compiler
+"""
+

--- a/test/bin/local-solver-picks-higher-version.t/repo/packages/base-unix/base-unix.base/opam
+++ b/test/bin/local-solver-picks-higher-version.t/repo/packages/base-unix/base-unix.base/opam
@@ -1,0 +1,6 @@
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+description: """
+Unix library distributed with the OCaml compiler
+"""
+

--- a/test/bin/local-solver-picks-higher-version.t/repo/packages/dune/dune.2.9.1/opam
+++ b/test/bin/local-solver-picks-higher-version.t/repo/packages/dune/dune.2.9.1/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+synopsis: "Fast, portable, and opinionated build system"
+description: """
+
+dune is a build system that was designed to simplify the release of
+Jane Street packages. It reads metadata from "dune" files following a
+very simple s-expression syntax.
+
+dune is fast, has very low-overhead, and supports parallel builds on
+all platforms. It has no system dependencies; all you need to build
+dune or packages using dune is OCaml. You don't need make or bash
+as long as the packages themselves don't use bash explicitly.
+
+dune supports multi-package development by simply dropping multiple
+repositories into the same directory.
+
+It also supports multi-context builds, such as building against
+several opam roots/switches simultaneously. This helps maintaining
+packages across several versions of OCaml and gives cross-compilation
+for free.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+conflicts: [
+  "merlin" {< "3.4.0"}
+  "ocaml-lsp-server" {< "1.3.0"}
+  "dune-configurator" {< "2.3.0"}
+  "odoc" {< "1.3.0"}
+  "dune-release" {< "1.3.0"}
+  "js_of_ocaml-compiler" {< "3.6.0"}
+  "jbuilder" {= "transition"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
+  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
+  ["ocaml" "bootstrap.ml" "-j" jobs]
+  ["./dune.exe" "build" "-p" name "--profile" "dune-bootstrap" "-j" jobs]
+]
+depends: [
+  # Please keep the lower bound in sync with .github/workflows/workflow.yml,
+  # dune-project and min_ocaml_version in bootstrap.ml
+  ("ocaml" {>= "4.08"} | ("ocaml" {< "4.08~~"} & "ocamlfind-secondary"))
+  "base-unix"
+  "base-threads"
+]
+x-commit-hash: "e41c66259135d6d1d72b031be6684bf8826a2586"
+url {
+  src: "https://github.com/ocaml/dune/releases/download/2.9.1/dune-2.9.1.tbz"
+  checksum: [
+    "sha256=b374feb22b34099ccc6dd32128e18d088ff9a81837952b29f05110b308c09f26"
+    "sha512=fce1aa520db785c25ded75a959e9dafeb7887d4f5deeb14b044cd5b9e2d235dca24589d794d2f01513765bc4764cf72f8659bd15f3a4fc06efa61363dc5d709b"
+  ]
+}

--- a/test/bin/local-solver-picks-higher-version.t/repo/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.1/opam
+++ b/test/bin/local-solver-picks-higher-version.t/repo/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Official release 4.13.1"
+maintainer: "platform@lists.ocaml.org"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml"
+depends: [
+  "ocaml" {= "4.13.1" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-options-vanilla" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "-C"
+    "CC=cc" {os = "openbsd" | os = "macos"}
+    "ASPP=cc -c" {os = "openbsd" | os = "macos"}
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.13.1.tar.gz"
+  checksum: "sha256=194c7988cc1fd1c64f53f32f2f7551e5309e44d914d6efc7e2e4d002296aeac4"
+}
+extra-files: ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
+  {failure & jobs > 1}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
+]

--- a/test/bin/local-solver-picks-higher-version.t/repo/packages/ocaml-config/ocaml-config.2/opam
+++ b/test/bin/local-solver-picks-higher-version.t/repo/packages/ocaml-config/ocaml-config.2/opam
@@ -1,0 +1,21 @@
+opam-version: "2.0"
+synopsis: "OCaml Switch Configuration"
+description: """
+This package is used by the OCaml package to set-up its variables."""
+maintainer: "platform@lists.ocaml.org"
+authors: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "David Allsopp <david.allsopp@metastack.com>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml-base-compiler" {>= "4.12.0~"} |
+  "ocaml-variants" {>= "4.12.0~"} |
+  "ocaml-system" {>= "4.12.0~"}
+]
+substs: "gen_ocaml_config.ml"
+extra-files: [
+  ["gen_ocaml_config.ml.in" "md5=a4b41e3236593d8271295b84b0969172"]
+  ["ocaml-config.install" "md5=8e50c5e2517d3463b3aad649748cafd7"]
+]

--- a/test/bin/local-solver-picks-higher-version.t/repo/packages/ocaml-options-vanilla/ocaml-options-vanilla.1/opam
+++ b/test/bin/local-solver-picks-higher-version.t/repo/packages/ocaml-options-vanilla/ocaml-options-vanilla.1/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis: "Ensure that OCaml is compiled with no special options enabled"
+depends: [
+  "ocaml-base-compiler" {post} |
+  "ocaml-system" {post} |
+  "ocaml-variants" {post & >= "4.12.0~"}
+]
+conflicts: [
+  "ocaml-option-32bit"
+  "ocaml-option-afl"
+  "ocaml-option-bytecode-only"
+  "ocaml-option-default-unsafe-string"
+  "ocaml-option-flambda"
+  "ocaml-option-fp"
+  "ocaml-option-musl"
+  "ocaml-option-no-flat-float-array"
+  "ocaml-option-spacetime"
+  "ocaml-option-static"
+  "ocaml-option-nnp"
+  "ocaml-option-nnpchecker"
+]
+maintainer: "platform@lists.ocaml.org"
+flags: compiler

--- a/test/bin/local-solver-picks-higher-version.t/repo/packages/ocaml/ocaml.4.13.1/opam
+++ b/test/bin/local-solver-picks-higher-version.t/repo/packages/ocaml/ocaml.4.13.1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+synopsis: "The OCaml compiler (virtual package)"
+description: """
+This package requires a matching implementation of OCaml,
+and polls it to initialise specific variables like `ocaml:native-dynlink`"""
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml-config" {>= "2"}
+  "ocaml-base-compiler" {>= "4.13.1~" & < "4.13.2~"} |
+  "ocaml-variants" {>= "4.13.1~" & < "4.13.2~"} |
+  "ocaml-system" {>= "4.13.1" & < "4.13.2~"}
+]
+setenv: [
+  [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
+  [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
+]
+build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
+build-env: CAML_LD_LIBRARY_PATH = ""
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "Jérôme Vouillon"
+]

--- a/test/bin/local-solver-picks-higher-version.t/repo/repo
+++ b/test/bin/local-solver-picks-higher-version.t/repo/repo
@@ -1,0 +1,1 @@
+opam-version: "2.0"

--- a/test/bin/local-solver-picks-higher-version.t/run.t
+++ b/test/bin/local-solver-picks-higher-version.t/run.t
@@ -52,6 +52,5 @@ opam-monorepo solver should pick a.0.2 here:
   ==> Querying opam database for their metadata and Dune compatibility.
   ==> Calculating exact pins for each of them.
   ==> Wrote lockfile with 1 entries to $TESTCASE_ROOT/test.opam.locked. You can now run opam monorepo pull to fetch their sources.
-  $ cat test.opam.locked | grep "\"a\""
+  $ cat test.opam.locked | grep "\"a\"\s\+{"
     "a" {= "0.2" & vendor}
-      "a"

--- a/test/bin/local-solver-picks-higher-version.t/run.t
+++ b/test/bin/local-solver-picks-higher-version.t/run.t
@@ -53,5 +53,5 @@ opam-monorepo solver should pick a.0.2 here:
   ==> Calculating exact pins for each of them.
   ==> Wrote lockfile with 1 entries to $TESTCASE_ROOT/test.opam.locked. You can now run opam monorepo pull to fetch their sources.
   $ cat test.opam.locked | grep "\"a\""
-    "a" {= "0.1" & vendor}
+    "a" {= "0.2" & vendor}
       "a"

--- a/test/bin/local-solver-picks-higher-version.t/run.t
+++ b/test/bin/local-solver-picks-higher-version.t/run.t
@@ -1,0 +1,57 @@
+With opam-0install solver, the context is responsible for defining the
+preference order between versions of a package.
+To stick to the default behaviour of the switch based context,
+the repository list based context should properly sort the candidates so
+that the solver picks the highest satisfying version.
+
+Here we define a package test that depends on a package `a`:
+
+  $ cat test.opam
+  opam-version: "2.0"
+  depends: [
+    "dune"
+    "a"
+  ]
+  x-opam-monorepo-opam-repositories: [
+    "file://$OPAM_MONOREPO_CWD/repo"
+  ]
+
+We have a local repo that defines two versions of `a`, both being satisfying
+solutions:
+
+  $ cat repo/packages/a/a.0.1/opam
+  opam-version: "2.0"
+  dev-repo: "git+https://a.com/a.git"
+  depends: [
+    "dune"
+  ]
+  url {
+    src: "https://a.com/a.0.1.tbz"
+    checksum: [
+      "sha256=0000000000000000000000000000000000000000000000000000000000000000"
+    ]
+  }
+  $ cat repo/packages/a/a.0.2/opam
+  opam-version: "2.0"
+  dev-repo: "git+https://a.com/a.git"
+  depends: [
+    "dune"
+  ]
+  url {
+    src: "https://a.com/a.0.2.tbz"
+    checksum: [
+      "sha256=0000000000000000000000000000000000000000000000000000000000000001"
+    ]
+  }
+
+opam-monorepo solver should pick a.0.2 here:
+
+  $ opam-monorepo lock
+  ==> Using 1 locally scanned package as the target.
+  ==> Found 9 opam dependencies for the target package.
+  ==> Querying opam database for their metadata and Dune compatibility.
+  ==> Calculating exact pins for each of them.
+  ==> Wrote lockfile with 1 entries to $TESTCASE_ROOT/test.opam.locked. You can now run opam monorepo pull to fetch their sources.
+  $ cat test.opam.locked | grep "\"a\""
+    "a" {= "0.1" & vendor}
+      "a"

--- a/test/bin/local-solver-picks-higher-version.t/test.opam
+++ b/test/bin/local-solver-picks-higher-version.t/test.opam
@@ -1,0 +1,8 @@
+opam-version: "2.0"
+depends: [
+  "dune"
+  "a"
+]
+x-opam-monorepo-opam-repositories: [
+  "file://$OPAM_MONOREPO_CWD/repo"
+]


### PR DESCRIPTION
It used to prefer older versions over newer ones. This was due to the solver context implementation!