### PR TITLE
Prevent unecessary selection of beta versions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,8 @@
 
 - Fix a bug where a package which had a single version that built with dune and got selected by the solver
   would be reported has having no version building with dune. (#245, @Leonidas-from-XIV)
+- Fix the solver so it does not select beta versions of the compiler unless it
+  has to. (#269, @NathanReb)
 
 ### Removed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,8 +30,8 @@
 
 - Fix a bug where a package which had a single version that built with dune and got selected by the solver
   would be reported has having no version building with dune. (#245, @Leonidas-from-XIV)
-- Fix the solver so it does not select beta versions of the compiler unless it
-  has to. (#269, @NathanReb)
+- Fix the solver so it does not select beta versions of the compiler unless
+  forced to by version constraints or `--ocaml-version`. (#269, @NathanReb)
 
 ### Removed
 

--- a/lib/opam.ml
+++ b/lib/opam.ml
@@ -48,6 +48,10 @@ let version_is_at_least locked_version =
   let version_formula = OpamFormula.Atom version_constraint in
   OpamFormula.check_version_formula version_formula
 
+let avoid_version opam =
+  let flags = OpamFile.OPAM.flags opam in
+  List.mem ~set:flags OpamTypes.Pkgflag_AvoidVersion
+
 let pull_tree ~url ~hashes ~dir global_state =
   let dir_str = Fpath.to_string dir in
   let cache_dir =

--- a/lib/opam.mli
+++ b/lib/opam.mli
@@ -149,6 +149,11 @@ module Value : sig
   end
 end
 
+val avoid_version : OpamFile.OPAM.t -> bool
+(** Returns whether this version should be avoided by telling whether it has
+    the avoid-version flag.
+    This flag is set for the compiler beta releases for instance. *)
+
 val depends_on_dune : allow_jbuilder:bool -> OpamTypes.filtered_formula -> bool
 (** Returns whether the given depends field formula contains a dependency to dune or jbuilder *)
 

--- a/lib/opam_solve.ml
+++ b/lib/opam_solve.ml
@@ -152,6 +152,15 @@ module Opam_monorepo_context (Base_context : BASE_CONTEXT) :
                    in
                    (version, Ok opam_file))
 
+  let sort_candidates versions =
+    let avoid_versions, regular_versions =
+      List.partition versions ~f:(fun (_version, opam_res) ->
+          match opam_res with
+          | Ok opam -> Opam.avoid_version opam
+          | Error _ -> false)
+    in
+    regular_versions @ avoid_versions
+
   let candidates
       {
         base_context;
@@ -170,6 +179,7 @@ module Opam_monorepo_context (Base_context : BASE_CONTEXT) :
         Base_context.candidates base_context name
         |> filter_candidates ~allow_jbuilder ~require_dune ~name
         |> remove_opam_provided ~opam_provided
+        |> sort_candidates
 
   let user_restrictions { base_context; _ } name =
     Base_context.user_restrictions base_context name

--- a/lib/opam_solve.ml
+++ b/lib/opam_solve.ml
@@ -152,7 +152,7 @@ module Opam_monorepo_context (Base_context : BASE_CONTEXT) :
                    in
                    (version, Ok opam_file))
 
-  let sort_candidates versions =
+  let demote_candidates_to_avoid versions =
     let avoid_versions, regular_versions =
       List.partition versions ~f:(fun (_version, opam_res) ->
           match opam_res with
@@ -179,7 +179,7 @@ module Opam_monorepo_context (Base_context : BASE_CONTEXT) :
         Base_context.candidates base_context name
         |> filter_candidates ~allow_jbuilder ~require_dune ~name
         |> remove_opam_provided ~opam_provided
-        |> sort_candidates
+        |> demote_candidates_to_avoid
 
   let user_restrictions { base_context; _ } name =
     Base_context.user_restrictions base_context name

--- a/test/bin/compiler-beta.t/repo-with-beta-ocaml/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0~beta1/opam
+++ b/test/bin/compiler-beta.t/repo-with-beta-ocaml/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0~beta1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "First beta release of OCaml 4.14.0"
+maintainer: "platform@lists.ocaml.org"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml#4.14"
+depends: [
+  "ocaml" {= "4.14.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-options-vanilla" {post}
+  "ocaml-beta" {opam-version < "2.1.0"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: [ compiler avoid-version ]
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--docdir=%{doc}%/ocaml"
+    "-C"
+    "CC=cc" {os = "openbsd" | os = "macos"}
+    "ASPP=cc -c" {os = "openbsd" | os = "macos"}
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.14.0-beta1.tar.gz"
+  checksum: "sha256=1b02000867fd20af59c2afa1eda411d064f02cf96227f7f3e07fbeb5492abe95"
+}
+extra-files: ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
+  {failure & jobs > 1}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
+]

--- a/test/bin/compiler-beta.t/repo-with-beta-ocaml/packages/ocaml/ocaml.4.14.0/opam
+++ b/test/bin/compiler-beta.t/repo-with-beta-ocaml/packages/ocaml/ocaml.4.14.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+synopsis: "The OCaml compiler (virtual package)"
+description: """
+This package requires a matching implementation of OCaml,
+and polls it to initialise specific variables like `ocaml:native-dynlink`"""
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml-config" {>= "2"}
+  "ocaml-base-compiler" {>= "4.14.0~" & < "4.14.1~"} |
+  "ocaml-variants" {>= "4.14.0~" & < "4.14.1~"} |
+  "ocaml-system" {>= "4.14.0" & < "4.14.1~"}
+]
+setenv: [
+  [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
+  [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
+]
+build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
+build-env: CAML_LD_LIBRARY_PATH = ""
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "Jérôme Vouillon"
+]
+flags: conf

--- a/test/bin/compiler-beta.t/repo-with-beta-ocaml/repo
+++ b/test/bin/compiler-beta.t/repo-with-beta-ocaml/repo
@@ -1,0 +1,1 @@
+opam-version: "2.0"

--- a/test/bin/compiler-beta.t/run.t
+++ b/test/bin/compiler-beta.t/run.t
@@ -103,8 +103,8 @@ should pick 4.13.1:
 
   $ opam-monorepo lock test > /dev/null
   $ opam show --no-lint -fdepends ./test.opam.locked | grep ocaml
-  "ocaml" {= "4.14.0"}
-  "ocaml-base-compiler" {= "4.14.0~beta1"}
+  "ocaml" {= "4.13.1"}
+  "ocaml-base-compiler" {= "4.13.1"}
   "ocaml-config" {= "2"}
   "ocaml-options-vanilla" {= "1"}
 

--- a/test/bin/compiler-beta.t/run.t
+++ b/test/bin/compiler-beta.t/run.t
@@ -15,87 +15,14 @@ We use the minimal repository which includes OCaml 4.13.1
 
   $ gen-minimal-repo
 
-We also use an extra repository which happens to contain the packages of the
-ongoing beta release of OCaml 4.14.1
+We also use an extra repository which contains the packages of the ongoing beta
+release of OCaml 4.14.0 i.e. ocaml.4.14.0 and ocaml-base-compiler.4.14.0~beta1.
+Those are the actual opam files extracted from upstream opam-repository. The
+relevant part to this feature is that the ocaml-base-compiler package has the
+avoid-version flag:
 
-  $ cat repo-with-beta-ocaml/packages/ocaml/ocaml.4.14.0/opam
-  opam-version: "2.0"
-  license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
-  synopsis: "The OCaml compiler (virtual package)"
-  description: """
-  This package requires a matching implementation of OCaml,
-  and polls it to initialise specific variables like `ocaml:native-dynlink`"""
-  maintainer: "platform@lists.ocaml.org"
-  depends: [
-    "ocaml-config" {>= "2"}
-    "ocaml-base-compiler" {>= "4.14.0~" & < "4.14.1~"} |
-    "ocaml-variants" {>= "4.14.0~" & < "4.14.1~"} |
-    "ocaml-system" {>= "4.14.0" & < "4.14.1~"}
-  ]
-  setenv: [
-    [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
-    [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
-    [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
-  ]
-  build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
-  build-env: CAML_LD_LIBRARY_PATH = ""
-  homepage: "https://ocaml.org"
-  bug-reports: "https://github.com/ocaml/opam-repository/issues"
-  authors: [
-    "Xavier Leroy"
-    "Damien Doligez"
-    "Alain Frisch"
-    "Jacques Garrigue"
-    "Didier Rémy"
-    "Jérôme Vouillon"
-  ]
-  flags: conf
-  $ cat repo-with-beta-ocaml/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0~beta1/opam
-  opam-version: "2.0"
-  synopsis: "First beta release of OCaml 4.14.0"
-  maintainer: "platform@lists.ocaml.org"
-  license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
-  authors: "Xavier Leroy and many contributors"
-  homepage: "https://ocaml.org"
-  bug-reports: "https://github.com/ocaml/opam-repository/issues"
-  dev-repo: "git+https://github.com/ocaml/ocaml#4.14"
-  depends: [
-    "ocaml" {= "4.14.0" & post}
-    "base-unix" {post}
-    "base-bigarray" {post}
-    "base-threads" {post}
-    "ocaml-options-vanilla" {post}
-    "ocaml-beta" {opam-version < "2.1.0"}
-  ]
-  conflict-class: "ocaml-core-compiler"
-  flags: [ compiler avoid-version ]
-  setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
-  build: [
-    [
-      "./configure"
-      "--prefix=%{prefix}%"
-      "--docdir=%{doc}%/ocaml"
-      "-C"
-      "CC=cc" {os = "openbsd" | os = "macos"}
-      "ASPP=cc -c" {os = "openbsd" | os = "macos"}
-    ]
-    [make "-j%{jobs}%"]
-  ]
-  install: [make "install"]
-  url {
-    src: "https://github.com/ocaml/ocaml/archive/4.14.0-beta1.tar.gz"
-    checksum: "sha256=1b02000867fd20af59c2afa1eda411d064f02cf96227f7f3e07fbeb5492abe95"
-  }
-  extra-files: ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
-  post-messages: [
-    "A failure in the middle of the build may be caused by build parallelism
-     (enabled by default).
-     Please file a bug report at https://github.com/ocaml/opam-repository/issues"
-    {failure & jobs > 1}
-    "You can try installing again including --jobs=1
-     to force a sequential build instead."
-    {failure & jobs > 1 & opam-version >= "2.0.5"}
-  ]
+  $ opam show --no-lint -fflags repo-with-beta-ocaml/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0~beta1/opam
+  compiler avoid-version
 
 Our package does not define an upper bound on ocaml but the beta should not be
 selected by default if there exist another solution, therefore here the solver

--- a/test/bin/compiler-beta.t/run.t
+++ b/test/bin/compiler-beta.t/run.t
@@ -1,15 +1,7 @@
 We have a simple project that only depends on OCaml
 
-  $ cat test.opam
-  opam-version: "2.0"
-  depends: [
-    "ocaml"
-    "dune"
-  ]
-  x-opam-monorepo-opam-repositories: [
-    "file://$OPAM_MONOREPO_CWD/minimal-repo"
-    "file://$OPAM_MONOREPO_CWD/repo-with-beta-ocaml"
-  ]
+  $ opam show --no-lint -fdepends ./test.opam
+  "ocaml" "dune"
 
 We use the minimal repository which includes OCaml 4.13.1
 
@@ -37,16 +29,8 @@ should pick 4.13.1:
 
 Now if we require ocaml >= 4.14, as the following package does:
 
-  $ cat test-requires-beta.opam
-  opam-version: "2.0"
-  depends: [
-    "ocaml" {>= "4.14"}
-    "dune"
-  ]
-  x-opam-monorepo-opam-repositories: [
-    "file://$OPAM_MONOREPO_CWD/minimal-repo"
-    "file://$OPAM_MONOREPO_CWD/repo-with-beta-ocaml"
-  ]
+  $ opam show --no-lint -fdepends ./test-requires-beta.opam
+  "ocaml" {>= "4.14"} "dune"
 
 The solver should be able to select the beta compiler since it is the only
 satisfying version available:

--- a/test/bin/compiler-beta.t/run.t
+++ b/test/bin/compiler-beta.t/run.t
@@ -1,0 +1,132 @@
+We have a simple project that only depends on OCaml
+
+  $ cat test.opam
+  opam-version: "2.0"
+  depends: [
+    "ocaml"
+    "dune"
+  ]
+  x-opam-monorepo-opam-repositories: [
+    "file://$OPAM_MONOREPO_CWD/minimal-repo"
+    "file://$OPAM_MONOREPO_CWD/repo-with-beta-ocaml"
+  ]
+
+We use the minimal repository which includes OCaml 4.13.1
+
+  $ gen-minimal-repo
+
+We also use an extra repository which happens to contain the packages of the
+ongoing beta release of OCaml 4.14.1
+
+  $ cat repo-with-beta-ocaml/packages/ocaml/ocaml.4.14.0/opam
+  opam-version: "2.0"
+  license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+  synopsis: "The OCaml compiler (virtual package)"
+  description: """
+  This package requires a matching implementation of OCaml,
+  and polls it to initialise specific variables like `ocaml:native-dynlink`"""
+  maintainer: "platform@lists.ocaml.org"
+  depends: [
+    "ocaml-config" {>= "2"}
+    "ocaml-base-compiler" {>= "4.14.0~" & < "4.14.1~"} |
+    "ocaml-variants" {>= "4.14.0~" & < "4.14.1~"} |
+    "ocaml-system" {>= "4.14.0" & < "4.14.1~"}
+  ]
+  setenv: [
+    [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
+    [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+    [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
+  ]
+  build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
+  build-env: CAML_LD_LIBRARY_PATH = ""
+  homepage: "https://ocaml.org"
+  bug-reports: "https://github.com/ocaml/opam-repository/issues"
+  authors: [
+    "Xavier Leroy"
+    "Damien Doligez"
+    "Alain Frisch"
+    "Jacques Garrigue"
+    "Didier Rémy"
+    "Jérôme Vouillon"
+  ]
+  flags: conf
+  $ cat repo-with-beta-ocaml/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0~beta1/opam
+  opam-version: "2.0"
+  synopsis: "First beta release of OCaml 4.14.0"
+  maintainer: "platform@lists.ocaml.org"
+  license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+  authors: "Xavier Leroy and many contributors"
+  homepage: "https://ocaml.org"
+  bug-reports: "https://github.com/ocaml/opam-repository/issues"
+  dev-repo: "git+https://github.com/ocaml/ocaml#4.14"
+  depends: [
+    "ocaml" {= "4.14.0" & post}
+    "base-unix" {post}
+    "base-bigarray" {post}
+    "base-threads" {post}
+    "ocaml-options-vanilla" {post}
+    "ocaml-beta" {opam-version < "2.1.0"}
+  ]
+  conflict-class: "ocaml-core-compiler"
+  flags: [ compiler avoid-version ]
+  setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+  build: [
+    [
+      "./configure"
+      "--prefix=%{prefix}%"
+      "--docdir=%{doc}%/ocaml"
+      "-C"
+      "CC=cc" {os = "openbsd" | os = "macos"}
+      "ASPP=cc -c" {os = "openbsd" | os = "macos"}
+    ]
+    [make "-j%{jobs}%"]
+  ]
+  install: [make "install"]
+  url {
+    src: "https://github.com/ocaml/ocaml/archive/4.14.0-beta1.tar.gz"
+    checksum: "sha256=1b02000867fd20af59c2afa1eda411d064f02cf96227f7f3e07fbeb5492abe95"
+  }
+  extra-files: ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+  post-messages: [
+    "A failure in the middle of the build may be caused by build parallelism
+     (enabled by default).
+     Please file a bug report at https://github.com/ocaml/opam-repository/issues"
+    {failure & jobs > 1}
+    "You can try installing again including --jobs=1
+     to force a sequential build instead."
+    {failure & jobs > 1 & opam-version >= "2.0.5"}
+  ]
+
+Our package does not define an upper bound on ocaml but the beta should not be
+selected by default if there exist another solution, therefore here the solver
+should pick 4.13.1:
+
+  $ opam-monorepo lock test > /dev/null
+  $ opam show --no-lint -fdepends ./test.opam.locked | grep ocaml
+  "ocaml" {= "4.14.0"}
+  "ocaml-base-compiler" {= "4.14.0~beta1"}
+  "ocaml-config" {= "2"}
+  "ocaml-options-vanilla" {= "1"}
+
+Now if we require ocaml >= 4.14, as the following package does:
+
+  $ cat test-requires-beta.opam
+  opam-version: "2.0"
+  depends: [
+    "ocaml" {>= "4.14"}
+    "dune"
+  ]
+  x-opam-monorepo-opam-repositories: [
+    "file://$OPAM_MONOREPO_CWD/minimal-repo"
+    "file://$OPAM_MONOREPO_CWD/repo-with-beta-ocaml"
+  ]
+
+The solver should be able to select the beta compiler since it is the only
+satisfying version available:
+
+  $ opam-monorepo lock test-requires-beta > /dev/null
+  $ opam show --no-lint -fdepends ./test-requires-beta.opam.locked | grep ocaml
+  "ocaml" {= "4.14.0"}
+  "ocaml-base-compiler" {= "4.14.0~beta1"}
+  "ocaml-config" {= "2"}
+  "ocaml-options-vanilla" {= "1"}

--- a/test/bin/compiler-beta.t/run.t
+++ b/test/bin/compiler-beta.t/run.t
@@ -25,7 +25,7 @@ avoid-version flag:
   compiler avoid-version
 
 Our package does not define an upper bound on ocaml but the beta should not be
-selected by default if there exist another solution, therefore here the solver
+selected by default if there exists another solution, therefore here the solver
 should pick 4.13.1:
 
   $ opam-monorepo lock test > /dev/null

--- a/test/bin/compiler-beta.t/test-requires-beta.opam
+++ b/test/bin/compiler-beta.t/test-requires-beta.opam
@@ -1,0 +1,9 @@
+opam-version: "2.0"
+depends: [
+  "ocaml" {>= "4.14"}
+  "dune"
+]
+x-opam-monorepo-opam-repositories: [
+  "file://$OPAM_MONOREPO_CWD/minimal-repo"
+  "file://$OPAM_MONOREPO_CWD/repo-with-beta-ocaml"
+]

--- a/test/bin/compiler-beta.t/test.opam
+++ b/test/bin/compiler-beta.t/test.opam
@@ -1,0 +1,9 @@
+opam-version: "2.0"
+depends: [
+  "ocaml"
+  "dune"
+]
+x-opam-monorepo-opam-repositories: [
+  "file://$OPAM_MONOREPO_CWD/minimal-repo"
+  "file://$OPAM_MONOREPO_CWD/repo-with-beta-ocaml"
+]


### PR DESCRIPTION
Fixes #265 !

Starting recently, beta versions of the compiler are released as `ocaml-base-compiler` and not `ocaml-variant` anymore. This had the side effect of making our solver pick beta versions if the constraints allowed it.

This fixes this issue but making the solver prefer regular versions over ones flagged with `avoid-version` in their opam metadata.

Such versions can still be selected when no regular version match the requirements.