### PR TITLE
Add a basic test for the depexts

### DIFF
--- a/test/bin/depext.t/a.opam
+++ b/test/bin/depext.t/a.opam
@@ -1,0 +1,9 @@
+opam-version: "2.0"
+depends: [
+  "dune"
+  "b"
+]
+x-opam-monorepo-opam-repositories: [
+  "file://$OPAM_MONOREPO_CWD/minimal-repo"
+  "file://$OPAM_MONOREPO_CWD/repo"
+]

--- a/test/bin/depext.t/repo/packages/b/b.1/opam
+++ b/test/bin/depext.t/repo/packages/b/b.1/opam
@@ -1,0 +1,14 @@
+opam-version: "2.0"
+depends: [
+  "dune"
+]
+depexts: [
+  ["libfantasydependency"]
+]
+dev-repo: "git+https://github.com/b/b"
+url {
+  src: "https://b.com/b.tbz"
+  checksum: [
+    "sha256=0000000000000000000000000000000000000000000000000000000000000000"
+  ]
+}

--- a/test/bin/depext.t/repo/repo
+++ b/test/bin/depext.t/repo/repo
@@ -1,0 +1,1 @@
+opam-version: "2.0"

--- a/test/bin/depext.t/run.t
+++ b/test/bin/depext.t/run.t
@@ -1,0 +1,28 @@
+We want to make sure picking depexts works, even if we vendor packages
+
+We setup the default base repository
+
+  $ gen-minimal-repo
+
+Here we define a package test that depends on a package `b`:
+
+  $ opam show --no-lint --raw -fdepends ./a.opam
+  "dune" "b"
+
+Package `b` has a `depext` on a fantasy OS package. We deliberately pick a
+fantasy name here to make sure the behaviour is the same on all platforms.
+
+  $ opam show --no-lint --raw -fdepexts ./repo/packages/b/b.1/opam
+  "libfantasydependency"
+
+We lock and expect the OS package to be part of the locked Opam file.
+
+  $ opam-monorepo lock a > /dev/null
+  $ opam show --no-lint --raw -fdepexts ./a.opam.locked
+  "libfantasydependency"
+
+Then we want to make sure `depext` works. Given the fantasy package does not
+exist, `depext` should not install any packages but still work successfully:
+
+  $ opam-monorepo depext --dry-run
+  ==> Using lockfile $TESTCASE_ROOT/a.opam.locked


### PR DESCRIPTION
We didn't have tests for the depexts, so here's a very basic one that shows that we capture transitive depexts correctly.

Writing a more complicated one is tricky because the packages installed depend on the OS and the state of the OS (whether they are installed or not) and I'd rather not maintain the package names that we use as dummies in the test because this will break on unknown platforms.