### PR TITLE
Update to cmdliner.1.1

### DIFF
--- a/bin/opam_monorepo.ml
+++ b/bin/opam_monorepo.ml
@@ -27,6 +27,43 @@ let init_opam () =
   OpamRepositoryConfig.init ();
   OpamStateConfig.init ~root_dir:root ()
 
+let default_run () = `Help (`Pager, None)
+
+let default = Cmdliner.Term.(ret (const default_run $ const ()))
+
+let info =
+  let open Cmdliner in
+  let doc = "the spice of build life" in
+  let sdocs = Manpage.s_common_options in
+  let man_xrefs = [ `Tool "dune"; `Tool "opam"; `Tool "git" ] in
+  let man =
+    [
+      `S Manpage.s_description;
+      `P
+        "The $(tname) plugin provides a convenient interface to bridge the \
+         $(b,opam) package manager with having a local copy of all the source \
+         code required to build a project using the $(b,dune) build tool.";
+      `P
+        "It works by analysing opam package metadata and calculating a set of \
+         URLs that can be downloaded or cloned into the local repository into \
+         a $(b,duniverse/) subdirectory. Once the external code has been \
+         pulled into the repository, a single $(b,dune build) command is \
+         sufficient to build the whole project in a standalone fashion, \
+         without opam being required. This is a particularly convenient way of \
+         publishing CLI tools to users who do not need the full power of opam.";
+      `P
+        "You can access the functionality directly via the $(i,monorepo-lock) \
+         and $(i,monorepo-pull) commands,";
+      `P
+        "Also see $(i,https://github.com/avsm/platform) for an example of a \
+         fully bootstrapping use of this tool.";
+    ]
+  in
+  Cmd.info "opam-monorepo" ~version:Common.Arg.version ~doc ~man_xrefs ~sdocs
+    ~man
+
+let main = Cmdliner.Cmd.group ~default info cmds
+
 let () =
   init_opam ();
-  Cmdliner.Term.(exit @@ eval_choice Default.cmd cmds)
+  Stdlib.exit @@ Cmdliner.Cmd.eval main

--- a/bin/opam_monorepo.ml
+++ b/bin/opam_monorepo.ml
@@ -66,4 +66,4 @@ let main = Cmdliner.Cmd.group ~default info cmds
 
 let () =
   init_opam ();
-  Stdlib.exit @@ Cmdliner.Cmd.eval main
+  Stdlib.exit @@ Cmdliner.Cmd.eval' main

--- a/cli/common.ml
+++ b/cli/common.ml
@@ -34,7 +34,7 @@ module Arg = struct
       Cmdliner.Arg.(value & flag & info [ "y"; "yes" ] ~doc)
 
   let non_empty_list_opt =
-    Cmdliner.Term.pure (function [] -> None | l -> Some l)
+    Cmdliner.Term.const (function [] -> None | l -> Some l)
 
   let keep_git_dir =
     let doc =

--- a/cli/common.ml
+++ b/cli/common.ml
@@ -88,6 +88,18 @@ module Arg = struct
     | Some v -> Build_info.V1.Version.to_string v
 end
 
+module Term = struct
+  let result_to_exit term =
+    let to_exit result =
+      match result with
+      | Ok () -> 0
+      | Error (`Msg msg) ->
+          Logs.err (fun l -> l "%s" msg);
+          1
+    in
+    Cmdliner.Term.(const to_exit $ term)
+end
+
 module Logs = struct
   let app ?src f =
     Logs.app ?src (fun l ->

--- a/cli/common.ml
+++ b/cli/common.ml
@@ -88,6 +88,11 @@ module Arg = struct
     | Some v -> Build_info.V1.Version.to_string v
 end
 
+let regular_error_exit =
+  Cmdliner.Cmd.Exit.info ~doc:"on regular opam-monorepo errors" 1
+
+let exit_codes = regular_error_exit :: Cmdliner.Cmd.Exit.defaults
+
 module Term = struct
   let result_to_exit term =
     let to_exit result =
@@ -95,7 +100,7 @@ module Term = struct
       | Ok () -> 0
       | Error (`Msg msg) ->
           Logs.err (fun l -> l "%s" msg);
-          1
+          Cmdliner.Cmd.Exit.info_code regular_error_exit
     in
     Cmdliner.Term.(const to_exit $ term)
 end

--- a/cli/common.mli
+++ b/cli/common.mli
@@ -41,6 +41,13 @@ module Arg : sig
   (** CLI version string *)
 end
 
+module Term : sig
+  val result_to_exit :
+    (unit, [< `Msg of string ]) result Cmdliner.Term.t -> int Cmdliner.Term.t
+  (** Converts a [_ result Term.t] to an [int Term.t] embedding the right exit
+      status. *)
+end
+
 val filter_duniverse :
   to_consider:string list option ->
   Duniverse.t ->

--- a/cli/common.mli
+++ b/cli/common.mli
@@ -12,7 +12,7 @@ module Arg : sig
       confusion when they are later passed to your main function.
       Example: [named (fun x -> `My_arg x] Arg.(value ...)] *)
 
-  val fpath : Fpath.t Cmdliner.Arg.converter
+  val fpath : Fpath.t Cmdliner.Arg.conv
 
   val root : [ `Root of Fpath.t ] Cmdliner.Term.t
   (** CLI option to specify the root directory of the project. Used to find root packages,

--- a/cli/common.mli
+++ b/cli/common.mli
@@ -48,6 +48,8 @@ module Term : sig
       status. *)
 end
 
+val exit_codes : Cmdliner.Cmd.Exit.info list
+
 val filter_duniverse :
   to_consider:string list option ->
   Duniverse.t ->

--- a/cli/default.ml
+++ b/cli/default.ml
@@ -1,36 +1,3 @@
 let run () = `Help (`Pager, None)
 
-let info =
-  let open Cmdliner in
-  let doc = "the spice of build life" in
-  let sdocs = Manpage.s_common_options in
-  let man_xrefs = [ `Tool "dune"; `Tool "opam"; `Tool "git" ] in
-  let man =
-    [
-      `S Manpage.s_description;
-      `P
-        "The $(tname) plugin provides a convenient interface to bridge the \
-         $(b,opam) package manager with having a local copy of all the source \
-         code required to build a project using the $(b,dune) build tool.";
-      `P
-        "It works by analysing opam package metadata and calculating a set of \
-         URLs that can be downloaded or cloned into the local repository into \
-         a $(b,duniverse/) subdirectory. Once the external code has been \
-         pulled into the repository, a single $(b,dune build) command is \
-         sufficient to build the whole project in a standalone fashion, \
-         without opam being required. This is a particularly convenient way of \
-         publishing CLI tools to users who do not need the full power of opam.";
-      `P
-        "You can access the functionality directly via the $(i,monorepo-lock) \
-         and $(i,monorepo-pull) commands,";
-      `P
-        "Also see $(i,https://github.com/avsm/platform) for an example of a \
-         fully bootstrapping use of this tool.";
-    ]
-  in
-  Term.info "opam-monorepo" ~version:Common.Arg.version ~doc ~man_xrefs ~sdocs
-    ~man
-
-let term = Cmdliner.Term.(ret (const run $ pure ()))
-
-let cmd = (term, info)
+let term = Cmdliner.Term.(ret (const run $ const ()))

--- a/cli/default.mli
+++ b/cli/default.mli
@@ -1,1 +1,1 @@
-val cmd : unit Cmdliner.Term.t * Cmdliner.Term.info
+val term : unit Cmdliner.Term.t

--- a/cli/depext.ml
+++ b/cli/depext.ml
@@ -46,7 +46,7 @@ let run (`Root root) (`Lockfile explicit_lockfile) dry_run (`Yes yes) () =
 open Cmdliner
 
 let info =
-  let exits = Term.default_exits in
+  let exits = Cmd.Exit.defaults in
   let doc = Fmt.str "install external dependencies" in
   let man =
     [
@@ -56,7 +56,7 @@ let info =
          lockfile.";
     ]
   in
-  Term.info "depext" ~doc ~exits ~man
+  Cmd.info "depext" ~doc ~exits ~man
 
 let dry_run =
   let doc =
@@ -71,4 +71,4 @@ let term =
     (const run $ Common.Arg.root $ Common.Arg.lockfile $ dry_run
    $ Common.Arg.yes $ Common.Arg.setup_logs ())
 
-let cmd = (term, info)
+let cmd = Cmd.v info term

--- a/cli/depext.ml
+++ b/cli/depext.ml
@@ -46,7 +46,7 @@ let run (`Root root) (`Lockfile explicit_lockfile) dry_run (`Yes yes) () =
 open Cmdliner
 
 let info =
-  let exits = Cmd.Exit.defaults in
+  let exits = Common.exit_codes in
   let doc = Fmt.str "install external dependencies" in
   let man =
     [

--- a/cli/depext.ml
+++ b/cli/depext.ml
@@ -67,7 +67,7 @@ let dry_run =
 
 let term =
   let open Term in
-  term_result
+  Common.Term.result_to_exit
     (const run $ Common.Arg.root $ Common.Arg.lockfile $ dry_run
    $ Common.Arg.yes $ Common.Arg.setup_logs ())
 

--- a/cli/depext.mli
+++ b/cli/depext.mli
@@ -1,1 +1,1 @@
-val cmd : unit Cmdliner.Cmd.t
+val cmd : int Cmdliner.Cmd.t

--- a/cli/depext.mli
+++ b/cli/depext.mli
@@ -1,1 +1,1 @@
-val cmd : unit Cmdliner.Term.t * Cmdliner.Term.info
+val cmd : unit Cmdliner.Cmd.t

--- a/cli/list_cmd.ml
+++ b/cli/list_cmd.ml
@@ -110,7 +110,7 @@ let short =
   Arg.(value & flag doc)
 
 let info =
-  let exits = Term.default_exits in
+  let exits = Cmd.Exit.defaults in
   let doc = Fmt.str "Display the list of monorepo packages" in
   let man =
     [
@@ -125,7 +125,7 @@ let info =
          packages and packages defined in overlays have a blue version.";
     ]
   in
-  Term.info "list" ~doc ~exits ~man
+  Cmd.info "list" ~doc ~exits ~man
 
 let term =
   let open Term in
@@ -133,4 +133,4 @@ let term =
     (const run $ Common.Arg.root $ Common.Arg.lockfile $ short
    $ Common.Arg.setup_logs ())
 
-let cmd = (term, info)
+let cmd = Cmd.v info term

--- a/cli/list_cmd.ml
+++ b/cli/list_cmd.ml
@@ -129,7 +129,7 @@ let info =
 
 let term =
   let open Term in
-  term_result
+  Common.Term.result_to_exit
     (const run $ Common.Arg.root $ Common.Arg.lockfile $ short
    $ Common.Arg.setup_logs ())
 

--- a/cli/list_cmd.ml
+++ b/cli/list_cmd.ml
@@ -110,7 +110,7 @@ let short =
   Arg.(value & flag doc)
 
 let info =
-  let exits = Cmd.Exit.defaults in
+  let exits = Common.exit_codes in
   let doc = Fmt.str "Display the list of monorepo packages" in
   let man =
     [

--- a/cli/list_cmd.mli
+++ b/cli/list_cmd.mli
@@ -1,1 +1,1 @@
-val cmd : unit Cmdliner.Cmd.t
+val cmd : int Cmdliner.Cmd.t

--- a/cli/list_cmd.mli
+++ b/cli/list_cmd.mli
@@ -1,1 +1,1 @@
-val cmd : unit Cmdliner.Term.t * Cmdliner.Term.info
+val cmd : unit Cmdliner.Cmd.t

--- a/cli/lock.ml
+++ b/cli/lock.ml
@@ -551,9 +551,10 @@ let info =
   Cmd.info "lock" ~doc ~exits ~man
 
 let term =
-  let open Term in
   Common.Term.result_to_exit
-    (const run $ Common.Arg.root $ recurse_opam $ build_only $ allow_jbuilder
-   $ ocaml_version $ packages $ Common.Arg.lockfile $ Common.Arg.setup_logs ())
+    Cmdliner.Term.(
+      const run $ Common.Arg.root $ recurse_opam $ build_only $ allow_jbuilder
+      $ ocaml_version $ packages $ Common.Arg.lockfile
+      $ Common.Arg.setup_logs ())
 
 let cmd = Cmd.v info term

--- a/cli/lock.ml
+++ b/cli/lock.ml
@@ -7,7 +7,7 @@ module Package_argument : sig
 
   val version : t -> OpamPackage.Version.t option
 
-  val converter : t Cmdliner.Arg.converter
+  val conv : t Cmdliner.Arg.conv
 
   val pp_styled : t Fmt.t
 end = struct
@@ -34,7 +34,7 @@ end = struct
   let pp ppf { name; version } =
     Fmt.pf ppf "%s%a" (OpamPackage.Name.to_string name) pp_version_opt version
 
-  let converter =
+  let conv =
     let parse s = Ok (from_string s) in
     Cmdliner.Arg.conv ~docv:"PACKAGE" (parse, pp)
 
@@ -510,7 +510,7 @@ let packages =
   let docv = "LOCAL_PACKAGE" in
   Common.Arg.named
     (fun x -> `Target_packages x)
-    Arg.(value & pos_all Package_argument.converter [] & info ~doc ~docv [])
+    Arg.(value & pos_all Package_argument.conv [] & info ~doc ~docv [])
 
 let ocaml_version =
   let doc = "Determined version to lock ocaml with in the lockfile." in
@@ -519,7 +519,7 @@ let ocaml_version =
     Arg.(value & opt (some string) None & info ~doc [ "ocaml-version" ])
 
 let info =
-  let exits = Term.default_exits in
+  let exits = Cmd.Exit.defaults in
   let doc = Fmt.str "analyse opam files to generate a project-wide lock file" in
   let man =
     [
@@ -548,7 +548,7 @@ let info =
          instructions there to add dune ports for the packages you need.";
     ]
   in
-  Term.info "lock" ~doc ~exits ~man
+  Cmd.info "lock" ~doc ~exits ~man
 
 let term =
   let open Term in
@@ -556,4 +556,4 @@ let term =
     (const run $ Common.Arg.root $ recurse_opam $ build_only $ allow_jbuilder
    $ ocaml_version $ packages $ Common.Arg.lockfile $ Common.Arg.setup_logs ())
 
-let cmd = (term, info)
+let cmd = Cmd.v info term

--- a/cli/lock.ml
+++ b/cli/lock.ml
@@ -519,7 +519,7 @@ let ocaml_version =
     Arg.(value & opt (some string) None & info ~doc [ "ocaml-version" ])
 
 let info =
-  let exits = Cmd.Exit.defaults in
+  let exits = Common.exit_codes in
   let doc = Fmt.str "analyse opam files to generate a project-wide lock file" in
   let man =
     [

--- a/cli/lock.ml
+++ b/cli/lock.ml
@@ -552,7 +552,7 @@ let info =
 
 let term =
   let open Term in
-  term_result
+  Common.Term.result_to_exit
     (const run $ Common.Arg.root $ recurse_opam $ build_only $ allow_jbuilder
    $ ocaml_version $ packages $ Common.Arg.lockfile $ Common.Arg.setup_logs ())
 

--- a/cli/lock.mli
+++ b/cli/lock.mli
@@ -1,1 +1,1 @@
-val cmd : unit Cmdliner.Cmd.t
+val cmd : int Cmdliner.Cmd.t

--- a/cli/lock.mli
+++ b/cli/lock.mli
@@ -1,1 +1,1 @@
-val cmd : unit Cmdliner.Term.t * Cmdliner.Term.info
+val cmd : unit Cmdliner.Cmd.t

--- a/cli/pull.ml
+++ b/cli/pull.ml
@@ -100,7 +100,7 @@ let run (`Yes yes) (`Root root) (`Lockfile explicit_lockfile)
 let info =
   let open Cmdliner in
   let doc = "fetch the dependencies sources as specified by the lockfile" in
-  let exits = Term.default_exits in
+  let exits = Cmd.Exit.defaults in
   let man =
     [
       `S Manpage.s_description;
@@ -115,7 +115,7 @@ let info =
          explicitly passed on the command line.";
     ]
   in
-  Term.info "pull" ~doc ~exits ~man
+  Cmd.info "pull" ~doc ~exits ~man
 
 let term =
   Cmdliner.Term.(
@@ -124,4 +124,4 @@ let term =
      $ Common.Arg.keep_git_dir $ Common.Arg.duniverse_repos
      $ Common.Arg.setup_logs ()))
 
-let cmd = (term, info)
+let cmd = Cmdliner.Cmd.v info term

--- a/cli/pull.ml
+++ b/cli/pull.ml
@@ -118,10 +118,10 @@ let info =
   Cmd.info "pull" ~doc ~exits ~man
 
 let term =
-  Cmdliner.Term.(
-    term_result
-      (const run $ Common.Arg.yes $ Common.Arg.root $ Common.Arg.lockfile
-     $ Common.Arg.keep_git_dir $ Common.Arg.duniverse_repos
-     $ Common.Arg.setup_logs ()))
+  Common.Term.result_to_exit
+    Cmdliner.Term.(
+      const run $ Common.Arg.yes $ Common.Arg.root $ Common.Arg.lockfile
+      $ Common.Arg.keep_git_dir $ Common.Arg.duniverse_repos
+      $ Common.Arg.setup_logs ())
 
 let cmd = Cmdliner.Cmd.v info term

--- a/cli/pull.ml
+++ b/cli/pull.ml
@@ -100,7 +100,7 @@ let run (`Yes yes) (`Root root) (`Lockfile explicit_lockfile)
 let info =
   let open Cmdliner in
   let doc = "fetch the dependencies sources as specified by the lockfile" in
-  let exits = Cmd.Exit.defaults in
+  let exits = Common.exit_codes in
   let man =
     [
       `S Manpage.s_description;

--- a/cli/pull.mli
+++ b/cli/pull.mli
@@ -1,1 +1,1 @@
-val cmd : unit Cmdliner.Cmd.t
+val cmd : int Cmdliner.Cmd.t

--- a/cli/pull.mli
+++ b/cli/pull.mli
@@ -1,1 +1,1 @@
-val cmd : unit Cmdliner.Term.t * Cmdliner.Term.info
+val cmd : unit Cmdliner.Cmd.t

--- a/dune-project
+++ b/dune-project
@@ -22,7 +22,7 @@ code required to build a project using the dune build tool.")
   dune-build-info
   base
   bos
-  cmdliner
+  (cmdliner (>= 1.1.0))
   fmt
   logs
   (opam-file-format (>= 2.1.0))

--- a/dune-project
+++ b/dune-project
@@ -22,7 +22,7 @@ code required to build a project using the dune build tool.")
   dune-build-info
   base
   bos
-  (cmdliner (< 1.1.0))
+  cmdliner
   fmt
   logs
   (opam-file-format (>= 2.1.0))

--- a/opam-monorepo.opam
+++ b/opam-monorepo.opam
@@ -19,7 +19,7 @@ depends: [
   "dune-build-info"
   "base"
   "bos"
-  "cmdliner"
+  "cmdliner" {>= "1.1.0"}
   "fmt"
   "logs"
   "opam-file-format" {>= "2.1.0"}

--- a/opam-monorepo.opam
+++ b/opam-monorepo.opam
@@ -19,7 +19,7 @@ depends: [
   "dune-build-info"
   "base"
   "bos"
-  "cmdliner" {< "1.1.0"}
+  "cmdliner"
   "fmt"
   "logs"
   "opam-file-format" {>= "2.1.0"}

--- a/opam-monorepo.opam.locked
+++ b/opam-monorepo.opam.locked
@@ -14,7 +14,7 @@ depends: [
   "bigarray-compat" {= "1.1.0"}
   "bigstringaf" {= "0.8.0"}
   "bos" {= "0.2.1+dune"}
-  "cmdliner" {= "1.0.4+dune"}
+  "cmdliner" {= "1.1.0+dune"}
   "conf-pkg-config" {= "2"}
   "cppo" {= "1.6.8"}
   "csexp" {= "1.5.1"}
@@ -109,8 +109,8 @@ pin-depends: [
     "https://github.com/dune-universe/bos/releases/download/v0.2.1%2Bdune/bos-0.2.1.dune.tbz"
   ]
   [
-    "cmdliner.1.0.4+dune"
-    "https://github.com/dune-universe/cmdliner/archive/v1.0.4+dune.tar.gz"
+    "cmdliner.1.1.0+dune"
+    "https://erratique.ch/software/cmdliner/releases/cmdliner-1.1.0.tbz"
   ]
   [
     "cppo.1.6.8"
@@ -239,6 +239,13 @@ pin-depends: [
 ]
 x-opam-monorepo-duniverse-dirs: [
   [
+    "https://erratique.ch/software/cmdliner/releases/cmdliner-1.1.0.tbz"
+    "cmdliner"
+    [
+      "sha512=e2fad706829e7b8b50d1a510b59b87e44294252d8e8bdd9d6cb07f435d7c1c123f82353eedf29e9a4b7768da485516b89b62bf956234e90d7eae1bbaae2c9263"
+    ]
+  ]
+  [
     "https://github.com/0install/0install/releases/download/v2.17/0install-v2.17.tbz"
     "0install"
     [
@@ -283,13 +290,6 @@ x-opam-monorepo-duniverse-dirs: [
     [
       "sha256=c6a34311946ff906824cedc2d12825ee9ad73b73bfa1581fb8100d6fc3dd5c35"
       "sha512=5a1422809050dfbebab9691f29109e8219e27ecc4bc50c2eb714dc59036811936e9c5860b13583ab0ba7c15a00ee5b515af25642cdc312a4814076d8e76e3fd7"
-    ]
-  ]
-  [
-    "https://github.com/dune-universe/cmdliner/archive/v1.0.4+dune.tar.gz"
-    "cmdliner"
-    [
-      "sha256=ffc09f07a9e394d6be4dbecea7add601ff00519a91dff4c95b9cd0a4aa60eceb"
     ]
   ]
   [

--- a/test/bin/invalid-package-version.t/run.t
+++ b/test/bin/invalid-package-version.t/run.t
@@ -40,7 +40,7 @@ to the test)
 
   $ opam-monorepo lock toonew 2> errors
   ==> Using 1 locally scanned package as the target.
-  [124]
+  [1]
   $ grep -Pazo "(?s)opam-monorepo: \[ERROR\].*(?=opam-monorepo)" < errors | head --bytes=-1
   opam-monorepo: [ERROR] There is no eligible version of a that matches >= 1.0
 
@@ -50,6 +50,6 @@ We should also produce the right error message with all the constraints when we 
   "dune" "depends-on-min-a" "a" {< "2.0"}
   $ opam-monorepo lock multiple-constraint 2> errors
   ==> Using 1 locally scanned package as the target.
-  [124]
+  [1]
   $ grep -Pazo "(?s)opam-monorepo: \[ERROR\].*(?=opam-monorepo)" < errors | head --bytes=-1
   opam-monorepo: [ERROR] There is no eligible version of a that matches >= 1.0

--- a/test/bin/invalid-package-version.t/run.t
+++ b/test/bin/invalid-package-version.t/run.t
@@ -40,7 +40,7 @@ to the test)
 
   $ opam-monorepo lock toonew 2> errors
   ==> Using 1 locally scanned package as the target.
-  [1]
+  [124]
   $ grep -Pazo "(?s)opam-monorepo: \[ERROR\].*(?=opam-monorepo)" < errors | head --bytes=-1
   opam-monorepo: [ERROR] There is no eligible version of a that matches >= 1.0
 
@@ -50,6 +50,6 @@ We should also produce the right error message with all the constraints when we 
   "dune" "depends-on-min-a" "a" {< "2.0"}
   $ opam-monorepo lock multiple-constraint 2> errors
   ==> Using 1 locally scanned package as the target.
-  [1]
+  [124]
   $ grep -Pazo "(?s)opam-monorepo: \[ERROR\].*(?=opam-monorepo)" < errors | head --bytes=-1
   opam-monorepo: [ERROR] There is no eligible version of a that matches >= 1.0

--- a/test/bin/missing-dune-project.t/run.t
+++ b/test/bin/missing-dune-project.t/run.t
@@ -16,4 +16,4 @@ either explicitly specify it on the command line or add a valid dune-project fil
   ==> Using 2 locally scanned packages as the targets.
   opam-monorepo: Could not infer the target lockfile name: Missing dune-project file at the root: $TESTCASE_ROOT/dune-project
                  Try setting it explicitly using --lockfile or add a project name in a root dune-project file.
-  [1]
+  [124]

--- a/test/bin/missing-dune-project.t/run.t
+++ b/test/bin/missing-dune-project.t/run.t
@@ -14,6 +14,6 @@ either explicitly specify it on the command line or add a valid dune-project fil
 
   $ opam-monorepo lock
   ==> Using 2 locally scanned packages as the targets.
-  opam-monorepo: Could not infer the target lockfile name: Missing dune-project file at the root: $TESTCASE_ROOT/dune-project
-                 Try setting it explicitly using --lockfile or add a project name in a root dune-project file.
-  [124]
+  opam-monorepo: [ERROR] Could not infer the target lockfile name: Missing dune-project file at the root: $TESTCASE_ROOT/dune-project
+  Try setting it explicitly using --lockfile or add a project name in a root dune-project file.
+  [1]

--- a/test/bin/opam-provided.t/run.t
+++ b/test/bin/opam-provided.t/run.t
@@ -112,8 +112,8 @@ be ignored is not a string.
   42
 
   $ opam-monorepo lock warning > /dev/null
-  opam-monorepo: Error in opam file $TESTCASE_ROOT/warning.opam, [8:31]-[8:33]: Expected a string or a list of strings, got: 42
-  [124]
+  opam-monorepo: [ERROR] Error in opam file $TESTCASE_ROOT/warning.opam, [8:31]-[8:33]: Expected a string or a list of strings, got: 42
+  [1]
 
 Similarly, we accept a list but it needs to be a list of strings which this is
 not:
@@ -121,8 +121,8 @@ not:
   $ opam show --no-lint --raw -fx-opam-monorepo-opam-provided ./warning-list.opam
   42 "fourtytwo"
   $ opam-monorepo lock warning > /dev/null
-  opam-monorepo: Error in opam file $TESTCASE_ROOT/warning.opam, [8:31]-[8:33]: Expected a string or a list of strings, got: 42
-  [124]
+  opam-monorepo: [ERROR] Error in opam file $TESTCASE_ROOT/warning.opam, [8:31]-[8:33]: Expected a string or a list of strings, got: 42
+  [1]
 
 It should also work to pass the version of the compiler and be respected for
 both `opam`-provided packages as well as those to be vendored:

--- a/test/bin/opam-provided.t/run.t
+++ b/test/bin/opam-provided.t/run.t
@@ -113,7 +113,7 @@ be ignored is not a string.
 
   $ opam-monorepo lock warning > /dev/null
   opam-monorepo: Error in opam file $TESTCASE_ROOT/warning.opam, [8:31]-[8:33]: Expected a string or a list of strings, got: 42
-  [1]
+  [124]
 
 Similarly, we accept a list but it needs to be a list of strings which this is
 not:
@@ -122,7 +122,7 @@ not:
   42 "fourtytwo"
   $ opam-monorepo lock warning > /dev/null
   opam-monorepo: Error in opam file $TESTCASE_ROOT/warning.opam, [8:31]-[8:33]: Expected a string or a list of strings, got: 42
-  [1]
+  [124]
 
 It should also work to pass the version of the compiler and be respected for
 both `opam`-provided packages as well as those to be vendored:


### PR DESCRIPTION
This PR updates the lockfile to use the latest version of cmdliner which introduced a new API and some deprecation warnings.

The upgrade turned some `1` exit codes in the test into `124` which stands for command line options parsing failure and was therefore misleading since those were clearly opam-monorepo errors.
I slightly changed how we turn results into exit codes to fix this but it also fixed other, pre-existing of occurences of false `124`.