### PR TITLE
Do not start generated README with backslash

### DIFF
--- a/lib/pull.ml
+++ b/lib/pull.ml
@@ -51,8 +51,7 @@ let pre_pull_clean_up ~full ~duniverse_dir duniverse =
           Fpath.(duniverse_dir / dir))
 
 let duniverse_documentation =
-  {|\
-# duniverse
+  {|# duniverse
 
 This folder contains vendored source code of the dependencies of the project,
 created by the [opam-monorepo](https://github.com/ocamllabs/opam-monorepo)


### PR DESCRIPTION
The \ syntax does not work in `{|` `|}` enclosed strings so just write the code without it, no big problem.

Closes #277

(`no changelog` label because it is not a user visible change between releases)