### PR TITLE
Improve vendor marking so that it requires no opam configuration

### DIFF
--- a/lib/lockfile.ml
+++ b/lib/lockfile.ml
@@ -115,11 +115,11 @@ module Depends = struct
           ( name,
             And
               ( Atom (Constraint (`Eq, FString version)),
-                Atom (Filter (FIdent ([], var, None))) ) )
+                Atom (Filter (FDefined (FIdent ([], var, None)))) ) )
       | Atom
           ( name,
             And
-              ( Atom (Filter (FIdent ([], var, None))),
+              ( Atom (Filter (FDefined (FIdent ([], var, None)))),
                 Atom (Constraint (`Eq, FString version)) ) )
         when variable_equal var Config.vendor_variable ->
           let version = OpamPackage.Version.of_string version in
@@ -136,7 +136,7 @@ module Depends = struct
     let version = package.version in
     let variable =
       OpamFormula.Atom
-        (OpamTypes.Filter (OpamTypes.FIdent ([], Config.vendor_variable, None)))
+        (OpamTypes.Filter (FDefined (FIdent ([], Config.vendor_variable, None))))
     in
     let version_constraint =
       OpamFormula.Atom

--- a/test/bin/invalid-package-version.t/run.t
+++ b/test/bin/invalid-package-version.t/run.t
@@ -24,7 +24,7 @@ opam-monorepo solver should successfully pick a.0.1:
   ==> Calculating exact pins for each of them.
   ==> Wrote lockfile with 1 entries to $TESTCASE_ROOT/existing.opam.locked. You can now run opam monorepo pull to fetch their sources.
   $ grep "\"a\"\s\+{" existing.opam.locked 
-    "a" {= "0.1" & vendor}
+    "a" {= "0.1" & ?vendor}
 
 Yet if we attempt to use the same package, but pick a version that doesn't
 exist in our repo:

--- a/test/bin/local-solver-picks-higher-version.t/run.t
+++ b/test/bin/local-solver-picks-higher-version.t/run.t
@@ -58,4 +58,4 @@ opam-monorepo solver should pick a.0.2 here:
   ==> Calculating exact pins for each of them.
   ==> Wrote lockfile with 1 entries to $TESTCASE_ROOT/test.opam.locked. You can now run opam monorepo pull to fetch their sources.
   $ cat test.opam.locked | grep "\"a\"\s\+{"
-    "a" {= "0.2" & vendor}
+    "a" {= "0.2" & ?vendor}

--- a/test/bin/opam-provided.t/run.t
+++ b/test/bin/opam-provided.t/run.t
@@ -24,7 +24,7 @@ The lockfile should thus contain the package "b" and mark it as `vendor` since
 `opam-monorepo` will vendor it.
 
   $ opam show --no-lint --raw -fdepends ./vendored.opam.locked
-  "b" {= "1" & vendor}
+  "b" {= "1" & ?vendor}
   "base-bigarray" {= "base"}
   "base-threads" {= "base"}
   "base-unix" {= "base"}
@@ -73,7 +73,7 @@ Locking it should work as usual
   "base-bigarray" {= "base"}
   "base-threads" {= "base"}
   "base-unix" {= "base"}
-  "depends-on-b" {= "1" & vendor}
+  "depends-on-b" {= "1" & ?vendor}
   "dune" {= "2.9.1"}
   "ocaml" {= "4.13.1"}
   "ocaml-base-compiler" {= "4.13.1"}

--- a/test/bin/require-cross-compiling-packages.t/run.t
+++ b/test/bin/require-cross-compiling-packages.t/run.t
@@ -56,14 +56,14 @@ overlays the solver picks the dune port as expected:
 
   $ opam-monorepo lock a > /dev/null
   $ opam show --no-lint -fdepends ./a.opam.locked | grep "\"b\""
-  "b" {= "0.1+dune" & vendor}
+  "b" {= "0.1+dune" & ?vendor}
 
 If we add the mirage overlays, the mirage port gets picked instead as its
 version is higher (+mirage):
 
   $ opam-monorepo lock a-with-mirage > /dev/null
   $ opam show --no-lint -fdepends ./a-with-mirage.opam.locked | grep "\"b\""
-  "b" {= "0.1+dune+mirage" & vendor}
+  "b" {= "0.1+dune+mirage" & ?vendor}
 
 So far so good. Problems arise when a new release of b hits upstream. We managed
 to upstream the dune port before `0.2` so the `0.2` release builds with dune.
@@ -84,7 +84,7 @@ Regular users of opam-monorepo will get the 0.2 version and be happy with it:
 
   $ opam-monorepo lock a > /dev/null
   $ opam show --no-lint -fdepends ./a.opam.locked | grep "\"b\""
-  "b" {= "0.2" & vendor}
+  "b" {= "0.2" & ?vendor}
 
 Mirage users on the other hand will get it as well, meaning they can't cross
 compile their unikernel anymore. The solver is happy but this will cause errors
@@ -92,7 +92,7 @@ at build time for them:
 
   $ opam-monorepo lock a-with-mirage > /dev/null
   $ grep "\"b\"\s\+{" a-with-mirage.opam.locked
-    "b" {= "0.2" & vendor}
+    "b" {= "0.2" & ?vendor}
 
 We added the --require-cross-compile flag to select packages that cross compile
 when available.
@@ -101,14 +101,14 @@ still get the latest release:
 
   $ opam-monorepo lock --require-cross-compile a > /dev/null
   $ opam show --no-lint -fdepends ./a.opam.locked | grep "\"b\""
-  "b" {= "0.2" & vendor}
+  "b" {= "0.2" & ?vendor}
 
 If we run it with mirage overlays though, it will detect that there exist
 versions that cross compile and favor those instead:
 
   $ opam-monorepo lock --require-cross-compile a-with-mirage > /dev/null
   $ opam show --no-lint -fdepends ./a-with-mirage.opam.locked | grep "\"b\""
-  "b" {= "0.1+dune+mirage" & vendor}
+  "b" {= "0.1+dune+mirage" & ?vendor}
 
 Note that if the upstream released version does cross compile, it can add the
 tag to be picked instead:
@@ -116,4 +116,4 @@ tag to be picked instead:
   $ echo "tags: [\"cross-compile\"]" >> opam-repository/packages/b/b.0.2/opam
   $ opam-monorepo lock --require-cross-compile a-with-mirage > /dev/null
   $ opam show --no-lint -fdepends ./a-with-mirage.opam.locked | grep "\"b\""
-  "b" {= "0.2" & vendor}
+  "b" {= "0.2" & ?vendor}

--- a/test/bin/simple-lock.t/run.t
+++ b/test/bin/simple-lock.t/run.t
@@ -32,11 +32,11 @@ The lockfile should contain the base packages, dune and our 2 dependencies
   synopsis: "opam-monorepo generated lockfile"
   maintainer: "opam-monorepo"
   depends: [
-    "b" {= "1" & vendor}
+    "b" {= "1" & ?vendor}
     "base-bigarray" {= "base"}
     "base-threads" {= "base"}
     "base-unix" {= "base"}
-    "c" {= "1" & vendor}
+    "c" {= "1" & ?vendor}
     "dune" {= "2.9.1"}
     "ocaml" {= "4.13.1"}
     "ocaml-base-compiler" {= "4.13.1"}


### PR DESCRIPTION
Fixes #257 

Opam has a way to allow undefined variables to be assigned a default value.
Our initial assumption was that it was doing this for all variables but it was wrong. Variables need to be applied the prefix, unary `?` operator.

This PR adds the operator before the `vendor` variable when writing the lockfile. It also expects the variable filter to be written this way when reading it back.