### PR TITLE
Make the source code compatible with OCaml 4.08 syntax

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,2 +1,3 @@
 version=0.20.1
 profile=conventional
+ocaml-version=4.08

--- a/cli/lock.ml
+++ b/cli/lock.ml
@@ -256,7 +256,7 @@ let opam_provided_packages ~opam_monorepo_cwd local_packages target_packages =
   let open Result.O in
   OpamPackage.Name.Set.fold
     (fun name acc ->
-      let* acc in
+      let* acc = acc in
       match OpamPackage.Name.Map.find_opt name local_packages with
       | Some (_version, opam) -> (
           match Source_opam_config.get ~opam_monorepo_cwd opam with


### PR DESCRIPTION
The let punning syntax is only compatible with 4.13+ so it makes sense to configure the formatter not to use it yet.