### PR TITLE
Relax ocaml compiler warning to allow ocaml-variants

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,7 +20,7 @@
   `x-opam-monorepo-global-opam-vars` to make `lock` fully reproducible.
   (#250, #253, @NathanReb)
 - Show an error message when the solver can't find any version that satisfies
-  the requested version constraint in the user's OPAM file (#215, #248,
+  the requested version constraint in the user's OPAM file (#215, #248, #290
   @Leonidas-from-XIV)
 - Allow packages to be marked as being provided by Opam and not to be pulled by
   `opam-monorepo`. To control this a new optional Opam file field,

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -30,7 +30,7 @@ let base_packages =
   |> List.map ~f:OpamPackage.Name.of_string
   |> OpamPackage.Name.Set.of_list
 
-let compiler_package_name = OpamPackage.Name.of_string "ocaml-base-compiler"
+let compiler_package_name = OpamPackage.Name.of_string "ocaml"
 
 let duniverse_opam_repo =
   "git+https://github.com/dune-universe/opam-overlays.git"


### PR DESCRIPTION
The warning introduced in #268 had the downside that it only worked when users would use `ocaml-base-compiler`. However, when using variants the compiler is not `ocaml-base-compiler` but `ocaml-variants`, as such the check needs to be relaxed to accept either of these options.

Sidenote: Our `List.mem` from `Stdext` does not support passing in a custom `equal` function, maybe a good idea to add?

Reported by @patricoferris