### PR TITLE
Filter `opam-provided` from duniverse

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,10 @@
 
 ### Fixed
 
+- Do not add `opam-provided` packages into pin-depends and duniverse
+  directories anymore, thus stop pulling packages that should be installed via
+  Opam (#302, @Leonidas-from-XIV)
+
 ### Removed
 
 ### Security

--- a/lib/duniverse.ml
+++ b/lib/duniverse.ml
@@ -207,9 +207,9 @@ let dev_repo_map_from_packages packages =
 let from_dependency_entries ~get_default_branch dependencies =
   let open Result.O in
   let summaries =
-    List.map
-      ~f:(fun Opam.Dependency_entry.{ package_summary; vendored = _ } ->
-        package_summary)
+    List.filter_map
+      ~f:(fun Opam.Dependency_entry.{ package_summary; vendored } ->
+        match vendored with true -> Some package_summary | false -> None)
       dependencies
   in
   let results =

--- a/test/bin/opam-provided.t/run.t
+++ b/test/bin/opam-provided.t/run.t
@@ -21,7 +21,7 @@ It should lock successfully.
   $ opam-monorepo lock vendored > /dev/null
 
 The lockfile should thus contain the package "b" and mark it as `vendor` since
-`opam-monorepo` will vendor it.
+`opam-monorepo` will vendor it. It should also add it to the duniverse-dirs.
 
   $ opam show --just-file --raw -fdepends ./vendored.opam.locked
   "b" {= "1" & ?vendor}
@@ -33,6 +33,12 @@ The lockfile should thus contain the package "b" and mark it as `vendor` since
   "ocaml-base-compiler" {= "4.13.1"}
   "ocaml-config" {= "2"}
   "ocaml-options-vanilla" {= "1"}
+  $ opam show --just-file --raw -fx-opam-monorepo-duniverse-dirs ./vendored.opam.locked
+  [
+    "https://b.com/b.tbz"
+    "b"
+    ["sha256=0000000000000000000000000000000000000000000000000000000000000000"]
+  ]
 
 Let's now check with the same Opam file but this one adds `opam`-provided.
 Asking for the value will return that "b" will be provided by Opam:
@@ -54,6 +60,11 @@ We should see that this package is not marked as `vendor` so if we run
   "ocaml-base-compiler" {= "4.13.1"}
   "ocaml-config" {= "2"}
   "ocaml-options-vanilla" {= "1"}
+
+It also should not be in `duniverse-dirs` in the locked Opam file:
+
+  $ opam show --just-file --raw -fx-opam-monorepo-duniverse-dirs ./opam-provided.opam.locked
+  
 
 What happens in the case that a package would be ok to vendor but the
 transitive dependency is `opam`-provided? In this case we have a package

--- a/test/lib/test_duniverse.ml
+++ b/test/lib/test_duniverse.ml
@@ -251,17 +251,7 @@ let test_from_dependency_entries =
           dependency_factory ~vendored:false ~dev_repo:"d" ~url_src:(Other "u")
             ~name:"y" ~version:"v" ();
         ]
-      ~expected:
-        (Ok
-           [
-             {
-               dir = "d";
-               url = Other "u";
-               hashes = [];
-               provided_packages = [ opam_factory ~name:"y" ~version:"v" ];
-             };
-           ])
-      ();
+      ~expected:(Ok []) ();
     make_test ~name:"Aggregates repos"
       ~dependency_entries:
         [


### PR DESCRIPTION
There is a bug where even despite the package marked as `opam-provided`, opam-monorepo will add it to the Duniverse and thus try to pull and build it.

The logic in the unit test was just plain wrong — an `opam-provided` package should not be part of the Duniverse.