### PR TITLE
Fix OCaml lower bound

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,3 +1,3 @@
 version=0.20.1
 profile=conventional
-ocaml-version=4.08
+ocaml-version=4.10

--- a/dune-project
+++ b/dune-project
@@ -17,7 +17,7 @@
 opam package manager with having a local copy of all the source
 code required to build a project using the dune build tool.")
  (depends
-  (ocaml (>= 4.08.0))
+  (ocaml (>= 4.10.0))
   dune-build-info
   base
   bos

--- a/opam-monorepo.opam
+++ b/opam-monorepo.opam
@@ -15,7 +15,7 @@ doc: "https://ocamllabs.github.io/opam-monorepo"
 bug-reports: "https://github.com/ocamllabs/opam-monorepo/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.10.0"}
   "dune-build-info"
   "base"
   "bos"


### PR DESCRIPTION
We discovered during the previous release that some of our vendored dependencies are not compatible with 4.08 anymore.
This PR bumps the lower bound to 4.10 accordingly.