### PR TITLE
Minimal update of lock file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 ### Added
 
 - Add a `--minimal-update` flag to `lock` to generate a lockfile
-  with minimum dependency changes from a previous lockfile. (#<PR_NUMBER>,
+  with minimum dependency changes from a previous lockfile. (#305,
   @NathanReb)
 
 ### Changed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ### Added
 
+- Add a `--minimal-update` flag to `lock` to generate a lockfile
+  with minimum dependency changes from a previous lockfile. (#<PR_NUMBER>,
+  @NathanReb)
+
 ### Changed
 
 ### Deprecated

--- a/cli/lock.ml
+++ b/cli/lock.ml
@@ -559,11 +559,8 @@ let require_cross_compile =
 
 let minimal_update =
   let doc =
-    "Generate a lock file with minimum dependency changes compared to the \
-     previous lock file. It can remove or add packages based on the dependency \
-     specification in the local opam files but will not upgrade or downgrade \
-     previously locked packages unless strictly necessary.\n\
-     Require a lock file to exist in the target lock file path."
+    "Prefer to keep versions as in the existing lock file, unless strictly \
+     necessary."
   in
   Common.Arg.named
     (fun x -> `Minimal_update x)

--- a/cli/lock.ml
+++ b/cli/lock.ml
@@ -427,7 +427,7 @@ let extract_source_config ~opam_monorepo_cwd ~opam_files target_packages =
 
 let run (`Root root) (`Recurse_opam recurse) (`Build_only build_only)
     (`Allow_jbuilder allow_jbuilder) (`Ocaml_version ocaml_version)
-    (`Require_cross_compile require_cross_compile)
+    (`Require_cross_compile require_cross_compile) (`Minimal_update _)
     (`Target_packages specified_packages) (`Lockfile explicit_lockfile) () =
   let open Result.O in
   let* local_packages = local_packages ~versions:specified_packages root in
@@ -532,6 +532,12 @@ let require_cross_compile =
     (fun x -> `Require_cross_compile x)
     Arg.(value & flag & info ~doc [ "require-cross-compile" ])
 
+let minimal_update =
+  let doc = "" in
+  Common.Arg.named
+    (fun x -> `Minimal_update x)
+    Arg.(value & flag & info ~doc [ "minimal-update" ])
+
 let info =
   let exits = Common.exit_codes in
   let doc = Fmt.str "analyse opam files to generate a project-wide lock file" in
@@ -568,7 +574,7 @@ let term =
   Common.Term.result_to_exit
     Cmdliner.Term.(
       const run $ Common.Arg.root $ recurse_opam $ build_only $ allow_jbuilder
-      $ ocaml_version $ require_cross_compile $ packages $ Common.Arg.lockfile
-      $ Common.Arg.setup_logs ())
+      $ ocaml_version $ require_cross_compile $ minimal_update $ packages
+      $ Common.Arg.lockfile $ Common.Arg.setup_logs ())
 
 let cmd = Cmd.v info term

--- a/doc/concepts.mld
+++ b/doc/concepts.mld
@@ -11,8 +11,8 @@ An [opam-monorepo] project uses 3 components in the source tree:
   mentioned in the lock file
 
 The two important commands are:
-- [opam monorepo lock], which will read the opam file and compute a solution
-  using the opam repository and the opam solver. It will create or update the
-  lock file with this solution.
+- {{!page-lock}[opam monorepo lock]}, which will read the opam file and compute
+  a solution using the opam repository and the opam solver. It will create or
+  update the lock file with this solution.
 - [opam monorepo pull] will read the lock file, download the dependencies, and
   unpack them into the [duniverse/] folder.

--- a/doc/index.mld
+++ b/doc/index.mld
@@ -9,5 +9,7 @@ Table of contents:
 - {{!page-faq}A FAQ} to answer common questions about [opam monorepo]
 - {{!page-concepts}A description of the concepts} behind [opam monorepo].
 - Some {{!page-workflows}common workflows} used in [opam monorepo] projects.
+- In depths documentation on {{!page-lock}locking dependencies}, the [lock]
+  command and how to get the best of it.
 - A {{!page-"opam-provided"} way to use [opam-monorepo] with non-[dune] dependencies}
   for when it is not possible to use [dune]

--- a/doc/lock.mld
+++ b/doc/lock.mld
@@ -19,6 +19,8 @@ add a new dependency or update a single package to be able to use this brand new
 function they just released.
 You can run [opam monorepo lock --minimal-update] for this. Assuming there is
 a pre-existing lock file, it will generate a new version of it with minimum
-changes in the selected versions of your dependencies. It will remove or add
-packages based on the changes in your local opam files but it will only upgrade
-or downgrade packages if it is strictly necessary.
+changes in the selected versions of your dependencies. It will prefer keeping
+versions from the previous lock file if possible.
+This mode is of course only useful if you run it after changing your
+dependency specification in one of your opam files as it will otherwise simply
+produce the same lock file.

--- a/doc/lock.mld
+++ b/doc/lock.mld
@@ -1,0 +1,24 @@
+{1 Locking dependencies}
+
+One of the features of opam-monorepo is to generate lock files, containing
+a solution for the entire, transitive dependency tree of the project. This
+allows to ensure all devs working on it will use the exact same versions for
+each opam package dependency.
+
+The [opam monorepo lock] command generates or updates lock files.
+
+{2 Updating an existing lock file}
+
+By default, [opam monorepo lock] will generate a fresh lock file without
+taking into account any previous lock file you may have.
+In practice that means that it will likely update a lot of your dependencies,
+depending on upstream releases of course.
+
+There are some scenarios where you might not want to update all of it but simply
+add a new dependency or update a single package to be able to use this brand new
+function they just released.
+You can run [opam monorepo lock --minimal-update] for this. Assuming there is
+a pre-existing lock file, it will generate a new version of it with minimum
+changes in the selected versions of your dependencies. It will remove or add
+packages based on the changes in your local opam files but it will only upgrade
+or downgrade packages if it is strictly necessary.

--- a/lib/lockfile.ml
+++ b/lib/lockfile.ml
@@ -297,6 +297,8 @@ let ocaml_version { depends; _ } =
       | true -> Some (OpamPackage.version package)
       | false -> None)
 
+let depends t = t.depends
+
 let url_to_duniverse_url url =
   let url_res = Duniverse.Repo.Url.from_opam_url url in
   Result.map_error url_res ~f:(function `Msg msg ->

--- a/lib/lockfile.mli
+++ b/lib/lockfile.mli
@@ -1,5 +1,10 @@
 type t
 
+module Depends : sig
+  type dependency = { package : OpamPackage.t; vendored : bool }
+  type t = dependency list
+end
+
 val create :
   source_config:Source_opam_config.t ->
   root_packages:OpamPackage.Name.Set.t ->
@@ -9,6 +14,7 @@ val create :
   unit ->
   t
 
+val depends : t -> Depends.t
 val to_duniverse : t -> (Duniverse.t, [ `Msg of string ]) result
 val ocaml_version : t -> OpamPackage.Version.t option
 

--- a/lib/opam_solve.mli
+++ b/lib/opam_solve.mli
@@ -16,7 +16,7 @@ val calculate :
   build_only:bool ->
   allow_jbuilder:bool ->
   require_cross_compile:bool ->
-  ?preferred_versions:OpamTypes.version OpamPackage.Name.Map.t ->
+  preferred_versions:OpamTypes.version OpamPackage.Name.Map.t ->
   local_opam_files:(OpamTypes.version * OpamFile.OPAM.t) OpamPackage.Name.Map.t ->
   target_packages:OpamPackage.Name.Set.t ->
   opam_provided:OpamPackage.Name.Set.t ->

--- a/lib/opam_solve.mli
+++ b/lib/opam_solve.mli
@@ -16,6 +16,7 @@ val calculate :
   build_only:bool ->
   allow_jbuilder:bool ->
   require_cross_compile:bool ->
+  ?preferred_versions:OpamTypes.version OpamPackage.Name.Map.t ->
   local_opam_files:(OpamTypes.version * OpamFile.OPAM.t) OpamPackage.Name.Map.t ->
   target_packages:OpamPackage.Name.Set.t ->
   opam_provided:OpamPackage.Name.Set.t ->

--- a/test/bin/minimal-update.t/minimal-update.opam
+++ b/test/bin/minimal-update.t/minimal-update.opam
@@ -1,0 +1,10 @@
+opam-version: "2.0"
+depends: [
+  "dune"
+  "a"
+  "b"
+]
+x-opam-monorepo-opam-repositories: [
+  "file://$OPAM_MONOREPO_CWD/minimal-repo"
+  "file://$OPAM_MONOREPO_CWD/repo"
+]

--- a/test/bin/minimal-update.t/repo/packages/a/a.0.1/opam
+++ b/test/bin/minimal-update.t/repo/packages/a/a.0.1/opam
@@ -1,0 +1,11 @@
+opam-version: "2.0"
+depends: [
+  "dune"
+]
+dev-repo: "git+https://github.com/a/a"
+url {
+  src: "https://a.com/a.tbz"
+  checksum: [
+    "sha256=0000000000000000000000000000000000000000000000000000000000000000"
+  ]
+}

--- a/test/bin/minimal-update.t/repo/packages/b/b.0.1/opam
+++ b/test/bin/minimal-update.t/repo/packages/b/b.0.1/opam
@@ -1,0 +1,11 @@
+opam-version: "2.0"
+depends: [
+  "dune"
+]
+dev-repo: "git+https://github.com/b/b"
+url {
+  src: "https://b.com/b.tbz"
+  checksum: [
+    "sha256=0000000000000000000000000000000000000000000000000000000000000001"
+  ]
+}

--- a/test/bin/minimal-update.t/repo/packages/c/c.0.1/opam
+++ b/test/bin/minimal-update.t/repo/packages/c/c.0.1/opam
@@ -1,0 +1,11 @@
+opam-version: "2.0"
+depends: [
+  "dune"
+]
+dev-repo: "git+https://github.com/c/c"
+url {
+  src: "https://c.com/c.tbz"
+  checksum: [
+    "sha256=0000000000000000000000000000000000000000000000000000000000000002"
+  ]
+}

--- a/test/bin/minimal-update.t/repo/repo
+++ b/test/bin/minimal-update.t/repo/repo
@@ -1,0 +1,1 @@
+opam-version: "2.0"

--- a/test/bin/minimal-update.t/run.t
+++ b/test/bin/minimal-update.t/run.t
@@ -52,3 +52,17 @@ Locking with --minimal-update should update b but not a:
   "a" {= "0.1" & ?vendor}
   "b" {= "0.2" & ?vendor}
   "c" {= "0.1" & ?vendor}
+
+Alternatively, if we remove a dependency:
+
+  $ sed -i '/"c"/d' ./minimal-update.opam
+  $ opam show --just-file -fdepends ./minimal-update.opam
+  "dune" "a" "b" {>= "0.2"}
+
+Locking with `--minimal-update` should still allow removing the unnecessary
+package from the lock file:
+
+  $ opam-monorepo lock --minimal-update > /dev/null
+  $ opam show --just-file -fdepends ./minimal-update.opam.locked | grep -e "\"b\"" -e "\"a\"" -e "\"c\""
+  "a" {= "0.1" & ?vendor}
+  "b" {= "0.2" & ?vendor}

--- a/test/bin/minimal-update.t/run.t
+++ b/test/bin/minimal-update.t/run.t
@@ -34,8 +34,8 @@ flag. This should add c to the lock file while keeping a and b to their previous
 
   $ opam-monorepo lock --minimal-update > /dev/null
   $ opam show --just-file -fdepends ./minimal-update.opam.locked | grep -e "\"b\"" -e "\"a\"" -e "\"c\""
-  "a" {= "0.2" & ?vendor}
-  "b" {= "0.2" & ?vendor}
+  "a" {= "0.1" & ?vendor}
+  "b" {= "0.1" & ?vendor}
   "c" {= "0.1" & ?vendor}
 
 Now say we want to also update b because we need a feature that is only
@@ -49,6 +49,6 @@ Locking with --minimal-update should update b but not a:
 
   $ opam-monorepo lock --minimal-update > /dev/null
   $ opam show --just-file -fdepends ./minimal-update.opam.locked | grep -e "\"b\"" -e "\"a\"" -e "\"c\""
-  "a" {= "0.2" & ?vendor}
+  "a" {= "0.1" & ?vendor}
   "b" {= "0.2" & ?vendor}
   "c" {= "0.1" & ?vendor}

--- a/test/bin/minimal-update.t/run.t
+++ b/test/bin/minimal-update.t/run.t
@@ -1,5 +1,5 @@
 We have a simple project with a single package which depends on
-packages a and b: 
+packages 'a' and 'b': 
 
   $ opam show --just-file -fdepends ./minimal-update.opam
   dune, a, b
@@ -13,16 +13,16 @@ our dependencies:
   "a" {= "0.1" & ?vendor}
   "b" {= "0.1" & ?vendor}
 
-Now we add a dependency to c to our project
+Now we add a dependency to 'c' to our project
 
   $ sed -i '/"b"/a "c"' minimal-update.opam 
   $ opam show --just-file -fdepends ./minimal-update.opam
   dune, a, b, c
 
-We would then like to update our lock file to include c but we do not
+We would then like to update our lock file to include 'c' but we do not
 want to update the other dependencies if it is not required
 
-Both a and b got a new release:
+Both 'a' and 'b' got a new release:
 
   $ mkdir repo/packages/a/a.0.2
   $ cp repo/packages/a/a.0.1/opam repo/packages/a/a.0.2/opam
@@ -30,7 +30,8 @@ Both a and b got a new release:
   $ cp repo/packages/b/b.0.1/opam repo/packages/b/b.0.2/opam
 
 To stick to the minimal lock file update, we use the --minimal-update
-flag. This should add c to the lock file while keeping a and b to their previous version.
+flag. This should add c to the lock file while keeping 'a' and 'b' to their
+previous version.
 
   $ opam-monorepo lock --minimal-update > /dev/null
   $ opam show --just-file -fdepends ./minimal-update.opam.locked | grep -e "\"b\"" -e "\"a\"" -e "\"c\""
@@ -38,14 +39,14 @@ flag. This should add c to the lock file while keeping a and b to their previous
   "b" {= "0.1" & ?vendor}
   "c" {= "0.1" & ?vendor}
 
-Now say we want to also update b because we need a feature that is only
+Now say we want to also update 'b' because we need a feature that is only
 available in the latest version:
 
   $ sed -i 's/"b"/"b" {>= "0.2"}/' minimal-update.opam
   $ opam show --just-file -fdepends ./minimal-update.opam
   "dune" "a" "b" {>= "0.2"} "c"
 
-Locking with --minimal-update should update b but not a:
+Locking with --minimal-update should update 'b' but not 'a':
 
   $ opam-monorepo lock --minimal-update > /dev/null
   $ opam show --just-file -fdepends ./minimal-update.opam.locked | grep -e "\"b\"" -e "\"a\"" -e "\"c\""

--- a/test/bin/minimal-update.t/run.t
+++ b/test/bin/minimal-update.t/run.t
@@ -1,0 +1,54 @@
+We have a simple project with a single package which depends on
+packages a and b: 
+
+  $ opam show --just-file -fdepends ./minimal-update.opam
+  dune, a, b
+
+We run an initial lock and get the following locked verions of
+our dependencies:
+
+  $ gen-minimal-repo
+  $ opam-monorepo lock > /dev/null
+  $ opam show --just-file -fdepends ./minimal-update.opam.locked | grep -e "\"b\"" -e "\"a\""
+  "a" {= "0.1" & ?vendor}
+  "b" {= "0.1" & ?vendor}
+
+Now we add a dependency to c to our project
+
+  $ sed -i '/"b"/a "c"' minimal-update.opam 
+  $ opam show --just-file -fdepends ./minimal-update.opam
+  dune, a, b, c
+
+We would then like to update our lock file to include c but we do not
+want to update the other dependencies if it is not required
+
+Both a and b got a new release:
+
+  $ mkdir repo/packages/a/a.0.2
+  $ cp repo/packages/a/a.0.1/opam repo/packages/a/a.0.2/opam
+  $ mkdir repo/packages/b/b.0.2
+  $ cp repo/packages/b/b.0.1/opam repo/packages/b/b.0.2/opam
+
+To stick to the minimal lock file update, we use the --minimal-update
+flag. This should add c to the lock file while keeping a and b to their previous version.
+
+  $ opam-monorepo lock --minimal-update > /dev/null
+  $ opam show --just-file -fdepends ./minimal-update.opam.locked | grep -e "\"b\"" -e "\"a\"" -e "\"c\""
+  "a" {= "0.2" & ?vendor}
+  "b" {= "0.2" & ?vendor}
+  "c" {= "0.1" & ?vendor}
+
+Now say we want to also update b because we need a feature that is only
+available in the latest version:
+
+  $ sed -i 's/"b"/"b" {>= "0.2"}/' minimal-update.opam
+  $ opam show --just-file -fdepends ./minimal-update.opam
+  "dune" "a" "b" {>= "0.2"} "c"
+
+Locking with --minimal-update should update b but not a:
+
+  $ opam-monorepo lock --minimal-update > /dev/null
+  $ opam show --just-file -fdepends ./minimal-update.opam.locked | grep -e "\"b\"" -e "\"a\"" -e "\"c\""
+  "a" {= "0.2" & ?vendor}
+  "b" {= "0.2" & ?vendor}
+  "c" {= "0.1" & ?vendor}


### PR DESCRIPTION
This PR adds a `--minimal-update` flag to `lock` which allows for updating the lock file, aiming at minimum changes in the dependencies.

When the flag is passed, the target lockfile (i.e. the one that it will write the generated lock file to) must already exists. It parsed and the list of packages extracted from it. It builds a map `name -> version` that is then passed to the solver. The map is used by the context to promote those version to the top of the preference sorted list of candidates for the package.
This result in different versions only getting picked if no solution exist with the version form the previous lock file. New packages are picked as they normally would and package that are not required anymore are also dropped without issues.

In short the preference order allows us to do everything we wanted from that feature making this a very easy to implement yet extremely useful feature!