### PR TITLE
Allow passing `x-opam-monorepo-*` solver config fields via the command line.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
   with minimum dependency changes from a previous lockfile. (#305,
   @NathanReb)
 - Add CLI options to complement or overwrite the solver configuration
-  set through opam extensions. (#<PR_NUMBER>, @NathanReb)
+  set through opam extensions. (#307, @NathanReb)
 
 ### Changed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,8 +5,8 @@
 - Add a `--minimal-update` flag to `lock` to generate a lockfile
   with minimum dependency changes from a previous lockfile. (#305,
   @NathanReb)
-- Add CLI options to complement or overwrite the solver configuration
-  set through opam extensions. (#307, @NathanReb)
+- Add command line options to complement or overwrite `x-opam-monorepo-*`
+  fields. (#307, @NathanReb)
 
 ### Changed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
 - Add a `--minimal-update` flag to `lock` to generate a lockfile
   with minimum dependency changes from a previous lockfile. (#305,
   @NathanReb)
+- Add CLI options to complement or overwrite the solver configuration
+  set through opam extensions. (#<PR_NUMBER>, @NathanReb)
 
 ### Changed
 

--- a/cli/lock.ml
+++ b/cli/lock.ml
@@ -446,7 +446,8 @@ let extract_source_config ~add_config ~overwrite_config ~opam_monorepo_cwd
       ~f:(Source_opam_config.get ~opam_monorepo_cwd)
   in
   let* local_opam_files_config = Source_opam_config.merge source_config_list in
-  Source_opam_config.make ~add_config ~overwrite_config ~local_opam_files_config
+  Source_opam_config.make ~opam_monorepo_cwd ~add_config ~overwrite_config
+    ~local_opam_files_config
 
 let run (`Root root) (`Recurse_opam recurse) (`Build_only build_only)
     (`Allow_jbuilder allow_jbuilder) (`Ocaml_version ocaml_version)

--- a/cli/lock.ml
+++ b/cli/lock.ml
@@ -434,7 +434,8 @@ let preferred_versions ~minimal_update ~root target_lockfile =
       in
       name_to_version_map
 
-let extract_source_config ~opam_monorepo_cwd ~opam_files target_packages =
+let extract_source_config ~add_config ~overwrite_config ~opam_monorepo_cwd
+    ~opam_files target_packages =
   let open Result.O in
   let target_opam_files =
     List.map (OpamPackage.Name.Set.elements target_packages) ~f:(fun name ->
@@ -444,12 +445,14 @@ let extract_source_config ~opam_monorepo_cwd ~opam_files target_packages =
     Result.List.map target_opam_files
       ~f:(Source_opam_config.get ~opam_monorepo_cwd)
   in
-  Source_opam_config.merge source_config_list
+  let* local_opam_files_config = Source_opam_config.merge source_config_list in
+  Source_opam_config.make ~add_config ~overwrite_config ~local_opam_files_config
 
 let run (`Root root) (`Recurse_opam recurse) (`Build_only build_only)
     (`Allow_jbuilder allow_jbuilder) (`Ocaml_version ocaml_version)
     (`Require_cross_compile require_cross_compile)
-    (`Minimal_update minimal_update) (`Target_packages specified_packages)
+    (`Minimal_update minimal_update) (`Add_config add_config)
+    (`Overwrite_config overwrite_config) (`Target_packages specified_packages)
     (`Lockfile explicit_lockfile) () =
   let open Result.O in
   let* local_packages = local_packages ~versions:specified_packages root in
@@ -461,7 +464,8 @@ let run (`Root root) (`Recurse_opam recurse) (`Build_only build_only)
   let* opam_files = local_paths_to_opam_map local_packages in
   let* lockfile_path = lockfile_path ~explicit_lockfile ~target_packages root in
   let* source_config =
-    extract_source_config ~opam_monorepo_cwd:root ~opam_files target_packages
+    extract_source_config ~add_config ~overwrite_config ~opam_monorepo_cwd:root
+      ~opam_files target_packages
   in
   let* opam_provided =
     opam_provided_packages ~opam_monorepo_cwd:root opam_files target_packages
@@ -496,6 +500,14 @@ let run (`Root root) (`Recurse_opam recurse) (`Build_only build_only)
   Ok ()
 
 open Cmdliner
+
+let add_config =
+  Common.Arg.named (fun x -> `Add_config x) Source_opam_config.cli_add_config
+
+let overwrite_config =
+  Common.Arg.named
+    (fun x -> `Overwrite_config x)
+    Source_opam_config.cli_overwrite_config
 
 let recurse_opam =
   let doc =
@@ -602,7 +614,8 @@ let term =
   Common.Term.result_to_exit
     Cmdliner.Term.(
       const run $ Common.Arg.root $ recurse_opam $ build_only $ allow_jbuilder
-      $ ocaml_version $ require_cross_compile $ minimal_update $ packages
-      $ Common.Arg.lockfile $ Common.Arg.setup_logs ())
+      $ ocaml_version $ require_cross_compile $ minimal_update $ add_config
+      $ overwrite_config $ packages $ Common.Arg.lockfile
+      $ Common.Arg.setup_logs ())
 
 let cmd = Cmd.v info term

--- a/doc/lock.mld
+++ b/doc/lock.mld
@@ -83,7 +83,7 @@ switch, local or remote. As long as you don't set any repository explicitly
 via [opam-monorepo]'s options or opam extension, it will be able to use
 anything setup in the switch. 
 
-File system URLs cannot use relative path. If you wish to use local folders for
+File system URLs cannot use relative paths. If you wish to use local folders for
 your repos, you can use the [$OPAM_MONOREPO_CWD] variable that will be replaced
 at runtime by [opam-monorepo]'s current working directory or the folder passed
 to [--root]. This will allow you to refer to repos defined within your workspace

--- a/doc/lock.mld
+++ b/doc/lock.mld
@@ -24,3 +24,175 @@ versions from the previous lock file if possible.
 This mode is of course only useful if you run it after changing your
 dependency specification in one of your opam files as it will otherwise simply
 produce the same lock file.
+
+{2 Configuring [lock]'s solver}
+
+To generate a lock file, [opam-monorepo] first needs to find a solution
+that satisfies the project's dependencies and runs an opam solver based
+on [0install] for that.
+
+There are certain aspects that can be configured either via the command line
+or in your opam files directly.
+
+{3 Opam Repositories}
+
+You can configure which repositories the solver will use to get the list
+of existing packages and their associated metadata.
+
+By default it will use the repositories set in your current switch.
+
+You can explicitly set the repositories to use, making [opam-monorepo] ignore
+the ones configured in the switch, along with in pins.
+You can do so by setting the [x-opam-monorepo-opam-repositories] extension
+in any of your local opam files. For instance:
+
+{[
+x-opam-monorepo-opam-repositories: [
+  "git+https://github.com/ocaml/opam-repositories"
+  "git+https://github.com/dune-universe/opam-overlays"
+]
+]}
+
+Alternatively you can set it via the command line by running:
+
+{[
+opam monorepo lock --opam-repositories \
+  '[git+https://github.com/ocaml/opam-repositories,git+https://github.com/dune-universe/opam-overlays]'
+]}
+
+The [--opam-repositories] option will overwrite any locally defined
+[x-opam-monorepo-opam-repositories] field. If you simply want to add extra
+repositories you can use [--add-opam-repositories] instead:
+
+{[
+opam monorepo lock --opam-repositories '[git+https://me.com/my-repo]'
+]}
+
+When the field is set in multiple opam files and eventually through the
+[--add-opam-repositories] option, they are combined into a set, removing any
+duplicates. That set of URLs is what the solver will then use to get the
+available packages metadata in place of the ones set in the switch.
+
+You can use any URL supported by opam, that includes local or remote git and
+tarball URLs as well as local folders.
+
+{b IMPORTANT NOTE}: this feature is still in development and only local
+folders URLs are supported at the moment. Support for remote URLs will be
+available shortly! In the meantime you can set any repository in your
+switch, local or remote. As long as you don't set any repository explicitly
+via [opam-monorepo]'s options or opam extension, it will be able to use
+anything setup in the switch. 
+
+File system URLs cannot use relative path. If you wish to use local folders for
+your repos, you can use the [$OPAM_MONOREPO_CWD] variable that will be replaced
+at runtime by [opam-monorepo]'s current working directory or the folder passed
+to [--root]. This will allow you to refer to repos defined within your workspace
+without writing path specific to your machine.
+
+For instance if you have a repository defined in a [data/repo] sub folder of
+your project, you can get the solver to use it by setting:
+
+{[
+x-opam-monorepo-opam-repositories: [
+  "file://$OPAM_MONOREPO_CWD/data/repo"
+]
+]}
+
+{3 Opam Global Variables}
+
+You can set the value of opam global variables such as [arch] or
+[os-distribution]. These can have an impact on the solution picked by the
+solver as some package availability or dependencies vary based on their value.
+
+By default [opam-monorepo] will use the variables set in your current switch.
+
+You can explicitly set the variables defined along with their value, making
+[opam-monorepo] ignore any variable defined in the switch.
+You can do so by setting the [x-opam-monorepo-opam-global-vars] opam extension.
+For instance:
+
+{[
+x-opam-monorepo-opam-global-vars: [
+  [ "arch" "x86_64" ]
+  [ "os-distribution" "debian" ]
+  [ "os-family" "debian" ]
+  [ "os-version" "testing" ]
+]
+]}
+
+Alternatively you can set it via the command line by running:
+
+{[
+opam monorepo lock \
+  --opam-global-vars [[arch,x86_64],[os-distribution,debian],[os-family,debian],[os-version,testing]]
+]}
+
+The [--opam-global-vars] option will overwrite any locally defined
+[x-opam-monorepo-opam-global-vars] field. If you simply want to define extra
+variables you can use [--add-opam-global-vars] instead:
+
+{[
+opam monorepo lock --add-global-vars [[some_var,some_value]]
+]}
+
+When the field is set in multiple opam files and eventually through the
+[--add-opam-global-vars] option, they are combined. A variable can appear
+multiple times as long as it is assigned the same value, it will error out
+otherwise.
+
+The variables can be assigned boolean, string or list of strings values.
+The syntax for the opam field is the following:
+
+{[
+x-opam-monorepo-global-vars: [
+  ["boolean_var" true]
+  ["string_var" "abc"]
+  ["string_list_var" ["abc" "def"]]
+]
+]}
+
+The syntax for command line argument is the following:
+
+{[
+--opam-global-vars [[boolean_var,true],[string_var,abc],[string_list_var,[abc,def]]]
+]}
+
+{3 Opam provided packages}
+
+This feature has its own {{!page-"opam-provided"}documentation page}.
+
+You can define a set of packages that should be installed via opam rather
+than incorporated into the duniverse. This will influence how the solver
+treats those packages (they do not have to build with dune for instance).
+
+By default all dependencies outside of [dune], [ocaml] and a few other base
+packages are treated as if they were to be incorporated in the duniverse.
+
+You can define which packages should be installed via opam by setting the
+[x-opam-monorepo-opam-provided] field in any of your local opam files. For
+instance:
+
+{[
+x-opam-monorepo-opam-provided: [
+  "tezos-rust-libs"
+  "ocamlfind"
+]
+]}
+
+Alternatively you can set it via the command line by running:
+
+{[
+opam monorepo lock --opam-provided [tezos-rust-libs,ocamlfind]
+]}
+
+The [--opam-provided] option will overwrite any locally defined
+[x-opam-monorepo-opam-provided] field. If you simply want to define extra
+opam provided packages you can use [--add-opam-provided] instead:
+
+{[
+opam monorepo lock --opam-provided [some-other-package]
+]}
+
+When the field is set in multiple opam files and eventually through the
+[--add-opam-provided] option, they are combinded into a set, removing
+duplicates.

--- a/doc/lock.mld
+++ b/doc/lock.mld
@@ -65,7 +65,7 @@ The [--opam-repositories] option will overwrite any locally defined
 repositories you can use [--add-opam-repositories] instead:
 
 {[
-opam monorepo lock --opam-repositories '[git+https://me.com/my-repo]'
+opam monorepo lock --add-opam-repositories '[git+https://me.com/my-repo]'
 ]}
 
 When the field is set in multiple opam files and eventually through the
@@ -190,7 +190,7 @@ The [--opam-provided] option will overwrite any locally defined
 opam provided packages you can use [--add-opam-provided] instead:
 
 {[
-opam monorepo lock --opam-provided [some-other-package]
+opam monorepo lock --add-opam-provided [some-other-package]
 ]}
 
 When the field is set in multiple opam files and eventually through the

--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,4 @@
 (library
  (name duniverse_lib)
- (libraries base bos fmt logs ocaml-version opam-0install opam-file-format
-   opam-format sexplib stdext threads uri))
+ (libraries base bos cmdliner fmt logs ocaml-version opam-0install
+   opam-file-format opam-format sexplib stdext threads uri))

--- a/lib/serial_shape.ml
+++ b/lib/serial_shape.ml
@@ -1,0 +1,225 @@
+open Import
+
+module Conv = struct
+  type ('repr, 'true_type) t = {
+    from_repr : 'repr -> ('true_type, Rresult.R.msg) result;
+    to_repr : 'true_type -> 'repr;
+    equal : ('true_type -> 'true_type -> bool) option;
+    pp : 'true_type Fmt.t option;
+  }
+
+  let make ~from_repr ~to_repr ?equal ?pp () = { from_repr; to_repr; equal; pp }
+end
+
+type _ t =
+  | Sbool : bool t
+  | Sstring : string t
+  | Slist : 'a t -> 'a list t
+  | Spair : 'a t * 'b t -> ('a * 'b) t
+  | Choice3 : 'a t * 'b t * 'c t -> [ `C1 of 'a | `C2 of 'b | `C3 of 'c ] t
+  | Conv : ('repr, 'true_type) Conv.t * 'repr t -> 'true_type t
+
+let bool = Sbool
+let string = Sstring
+let list s = Slist s
+let pair s s' = Spair (s, s')
+let choice3 s s' s'' = Choice3 (s, s', s'')
+let conv conv s = Conv (conv, s)
+
+let rec shallow_description : type a. a t -> string = function
+  | Slist _ -> "a list"
+  | Spair _ -> "a pair"
+  | Sstring -> "a string"
+  | Sbool -> "a boolean"
+  | Choice3 (s, s', s'') ->
+      let d = shallow_description s in
+      let d' = shallow_description s' in
+      let d'' = shallow_description s'' in
+      Printf.sprintf "%s, %s or %s" d d' d''
+  | Conv (_, s) -> shallow_description s
+
+let rec from_opam_val :
+    type a. a t -> OpamParserTypes.FullPos.value -> (a, Rresult.R.msg) result =
+ fun shape value ->
+  let open Result.O in
+  let parse_error () =
+    let expected = shallow_description shape in
+    Opam.Pos.unexpected_value_error ~expected value
+  in
+  match (shape, value) with
+  | Sbool, { pelem = Bool b; _ } -> Ok b
+  | Sstring, { pelem = String s; _ } -> Ok s
+  | Spair (s, s'), { pelem = List { pelem = [ v; v' ]; _ }; _ } ->
+      let* fst = from_opam_val s v in
+      let* snd = from_opam_val s' v' in
+      Ok (fst, snd)
+  | Slist s, { pelem = List _; _ } ->
+      let* l = Opam.Value.List.from_value (from_opam_val s) value in
+      Ok l
+  | Conv (conv, s), value ->
+      let* repr = from_opam_val s value in
+      conv.from_repr repr
+  | Choice3 (s, s', s''), value -> (
+      match from_opam_val s value with
+      | Ok c1 -> Ok (`C1 c1)
+      | Error _ -> (
+          match from_opam_val s' value with
+          | Ok c2 -> Ok (`C2 c2)
+          | Error _ -> (
+              match from_opam_val s'' value with
+              | Ok c3 -> Ok (`C3 c3)
+              | Error _ -> parse_error ())))
+  | _ -> parse_error ()
+
+let rec to_opam_val : type a. a t -> a -> OpamParserTypes.FullPos.value =
+ fun shape value ->
+  match (shape, value) with
+  | Sbool, b -> Opam.Pos.with_default (OpamParserTypes.FullPos.Bool b)
+  | Sstring, s -> Opam.Value.String.to_value s
+  | Spair (s, s'), (v, v') ->
+      let fst = to_opam_val s v in
+      let snd = to_opam_val s' v' in
+      Opam.Value.List.to_value Fun.id [ fst; snd ]
+  | Slist s, l -> Opam.Value.List.to_value (to_opam_val s) l
+  | Conv (conv, s), value ->
+      let repr = conv.to_repr value in
+      to_opam_val s repr
+  | Choice3 (s, _, _), `C1 v -> to_opam_val s v
+  | Choice3 (_, s, _), `C2 v -> to_opam_val s v
+  | Choice3 (_, _, s), `C3 v -> to_opam_val s v
+
+let unmatched_list_delimiter ~delim =
+  Rresult.R.error_msgf "unmatched list delimiter '%c'" delim
+
+let str_get_opt s i =
+  match s.[i] with c -> Some c | exception Invalid_argument _ -> None
+
+let split_list ~start ~len s =
+  let last = start + len - 1 in
+  let rec search_sep ~count_open ~acc ~current_elm_start i =
+    match str_get_opt s i with
+    | _ when i > last && count_open > 0 -> unmatched_list_delimiter ~delim:'['
+    | _ when i > last ->
+        let last =
+          String.sub s ~pos:current_elm_start ~len:(last + 1 - current_elm_start)
+        in
+        Ok (List.rev (last :: acc))
+    | Some '[' ->
+        search_sep ~count_open:(count_open + 1) ~acc ~current_elm_start (i + 1)
+    | Some (']' as delim) when count_open = 0 -> unmatched_list_delimiter ~delim
+    | Some ']' ->
+        search_sep ~count_open:(count_open - 1) ~acc ~current_elm_start (i + 1)
+    | Some ',' when count_open = 0 ->
+        let elm =
+          String.sub s ~pos:current_elm_start ~len:(i - current_elm_start)
+        in
+        search_sep ~count_open ~acc:(elm :: acc) ~current_elm_start:(i + 1)
+          (i + 1)
+    | Some _ -> search_sep ~count_open ~acc ~current_elm_start (i + 1)
+    | None -> assert false
+  in
+  if len = 0 then Ok []
+  else search_sep ~count_open:0 ~acc:[] ~current_elm_start:start start
+
+let parse_list s =
+  let len = String.length s in
+  if len = 0 then Ok []
+  else
+    match (s.[0], s.[len - 1]) with
+    | '[', ']' -> split_list ~start:1 ~len:(len - 2) s
+    | ('[' as delim), _ -> unmatched_list_delimiter ~delim
+    | _ -> split_list ~start:0 ~len s
+
+let rec cmdliner_parse : type a. a t -> string -> (a, Rresult.R.msg) result =
+ fun shape value ->
+  let open Result.O in
+  let parse_error () =
+    let expected = shallow_description shape in
+    Rresult.R.error_msgf "Expected %s but got: %s" expected value
+  in
+  match (shape, value) with
+  | Sbool, "true" -> Ok true
+  | Sbool, "false" -> Ok false
+  | Sstring, s -> Ok s
+  | Spair (s, s'), value -> (
+      let* l = parse_list value in
+      match l with
+      | [ v; v' ] ->
+          let* fst = cmdliner_parse s v in
+          let* snd = cmdliner_parse s' v' in
+          Ok (fst, snd)
+      | _ -> parse_error ())
+  | Slist s, value ->
+      let* l = parse_list value in
+      Result.List.map l ~f:(cmdliner_parse s)
+  | Conv (conv, s), value ->
+      let* repr = cmdliner_parse s value in
+      conv.from_repr repr
+  | Choice3 (s, s', s''), value -> (
+      match cmdliner_parse s value with
+      | Ok c1 -> Ok (`C1 c1)
+      | Error _ -> (
+          match cmdliner_parse s' value with
+          | Ok c2 -> Ok (`C2 c2)
+          | Error _ -> (
+              match cmdliner_parse s'' value with
+              | Ok c3 -> Ok (`C3 c3)
+              | Error _ -> parse_error ())))
+  | _ -> parse_error ()
+
+let rec cmdliner_print : type a. a t -> Format.formatter -> a -> unit =
+ fun shape fmt value ->
+  match (shape, value) with
+  | Sbool, b -> Fmt.pf fmt "%a" Fmt.bool b
+  | Sstring, s -> Fmt.pf fmt "%s" s
+  | Spair (s, s'), (v, v') ->
+      Fmt.pf fmt "[%a,%a]" (cmdliner_print s) v (cmdliner_print s') v'
+  | Slist s, l ->
+      Fmt.pf fmt "[%a]"
+        (Fmt.list ~sep:Fmt.(const char ',') (cmdliner_print s))
+        l
+  | Conv (conv, s), value ->
+      let repr = conv.to_repr value in
+      cmdliner_print s fmt repr
+  | Choice3 (s, _, _), `C1 v -> cmdliner_print s fmt v
+  | Choice3 (_, s, _), `C2 v -> cmdliner_print s fmt v
+  | Choice3 (_, _, s), `C3 v -> cmdliner_print s fmt v
+
+let cmdliner_conv shape =
+  let parse = cmdliner_parse shape in
+  let print = cmdliner_print shape in
+  Cmdliner.Arg.conv (parse, print)
+
+let rec equal : type a. a t -> a -> a -> bool =
+ fun shape v v' ->
+  match (shape, v, v') with
+  | Sbool, b, b' -> Bool.equal b b'
+  | Sstring, s, s' -> String.equal s s'
+  | Spair (sfst, ssnd), (fst, snd), (fst', snd') ->
+      equal sfst fst fst' && equal ssnd snd snd'
+  | Slist s, l, l' -> List.equal (equal s) l l'
+  | Choice3 (s, _, _), `C1 v, `C1 v' -> equal s v v'
+  | Choice3 (_, s, _), `C2 v, `C2 v' -> equal s v v'
+  | Choice3 (_, _, s), `C3 v, `C3 v' -> equal s v v'
+  | Choice3 _, _, _ -> false
+  | Conv ({ equal = Some eq; _ }, _), v, v' -> eq v v'
+  | Conv (conv, s), v, v' ->
+      let repr = conv.to_repr v in
+      let repr' = conv.to_repr v' in
+      equal s repr repr'
+
+let rec pp : type a. a t -> a Fmt.t =
+ fun shape fmt v ->
+  match (shape, v) with
+  | Sbool, b -> Fmt.bool fmt b
+  | Sstring, s -> Fmt.pf fmt "%S" s
+  | Spair (s, s'), (v, v') -> Fmt.pf fmt "(%a, %a)" (pp s) v (pp s') v'
+  | Slist s, l ->
+      Fmt.pf fmt "[%a]" (Fmt.list ~sep:Fmt.(const char ';') (pp s)) l
+  | Choice3 (s, _, _), `C1 v -> pp s fmt v
+  | Choice3 (_, s, _), `C2 v -> pp s fmt v
+  | Choice3 (_, _, s), `C3 v -> pp s fmt v
+  | Conv ({ pp = Some pp; _ }, _), v -> pp fmt v
+  | Conv (conv, s), v ->
+      let repr = conv.to_repr v in
+      pp s fmt repr

--- a/lib/serial_shape.ml
+++ b/lib/serial_shape.ml
@@ -60,8 +60,7 @@ let rec from_opam_val :
       let* snd = from_opam_val s' v' in
       Ok (fst, snd)
   | Slist s, { pelem = List _; _ } ->
-      let* l = Opam.Value.List.from_value (from_opam_val s) value in
-      Ok l
+      Opam.Value.List.from_value (from_opam_val s) value
   | Conv (conv, s), value -> (
       let* repr = from_opam_val s value in
       let res = conv.from_repr repr in

--- a/lib/serial_shape.ml
+++ b/lib/serial_shape.ml
@@ -62,9 +62,12 @@ let rec from_opam_val :
   | Slist s, { pelem = List _; _ } ->
       let* l = Opam.Value.List.from_value (from_opam_val s) value in
       Ok l
-  | Conv (conv, s), value ->
+  | Conv (conv, s), value -> (
       let* repr = from_opam_val s value in
-      conv.from_repr repr
+      let res = conv.from_repr repr in
+      match res with
+      | Ok _ as res -> res
+      | Error (`Msg msg) -> Opam.Pos.value_errorf ~value "%s" msg)
   | Choice2 (s, s'), value -> (
       match from_opam_val s value with
       | Ok c1 -> Ok (`C1 c1)

--- a/lib/serial_shape.ml
+++ b/lib/serial_shape.ml
@@ -146,7 +146,7 @@ let parse_list s =
     match (s.[0], s.[len - 1]) with
     | '[', ']' -> split_list ~start:1 ~len:(len - 2) s
     | ('[' as delim), _ -> unmatched_list_delimiter ~delim
-    | _ -> split_list ~start:0 ~len s
+    | _ -> Rresult.R.error_msg "list or pairs must be delimited by '[' and ']'"
 
 let rec cmdliner_parse : type a. a t -> string -> (a, Rresult.R.msg) result =
  fun shape value ->

--- a/lib/serial_shape.mli
+++ b/lib/serial_shape.mli
@@ -32,6 +32,7 @@ val string : string t
 val list : 'a t -> 'a list t
 val pair : 'a t -> 'b t -> ('a * 'b) t
 val conv : ('repr, 'true_type) Conv.t -> 'repr t -> 'true_type t
+val choice2 : 'a t -> 'b t -> [ `C1 of 'a | `C2 of 'b ] t
 
 val choice3 : 'a t -> 'b t -> 'c t -> [ `C1 of 'a | `C2 of 'b | `C3 of 'c ] t
 (** [choice3 s s' s''] allows for any of [s], [s'] or [s''].

--- a/lib/serial_shape.mli
+++ b/lib/serial_shape.mli
@@ -1,0 +1,63 @@
+(** Helpers to describe the OCaml shape of data and serialize/deserialize
+    it into different formats. *)
+
+module Conv : sig
+  type ('repr, 'true_type) t
+  (** Type of converters from representation types to the true type.
+    The representation type is the simplified type used for serialization
+    while the true type is the type of the value as we'd like to use it
+    in OCaml code.
+    For instance a set is usually converted to a list before serializing
+    it. In that scenario, the list is the representatio type and the set
+    the true type. *)
+
+  val make :
+    from_repr:('repr -> ('true_type, Rresult.R.msg) result) ->
+    to_repr:('true_type -> 'repr) ->
+    ?equal:('true_type -> 'true_type -> bool) ->
+    ?pp:'true_type Fmt.t ->
+    unit ->
+    ('repr, 'true_type) t
+  (** Build a converter out of conversion functions between the repr
+      and true type.
+      [equal] and [pp] are optional and mostly used for testing of this
+      module. *)
+end
+
+type 'a t
+(** Type for generic data shape *)
+
+val bool : bool t
+val string : string t
+val list : 'a t -> 'a list t
+val pair : 'a t -> 'b t -> ('a * 'b) t
+val conv : ('repr, 'true_type) Conv.t -> 'repr t -> 'true_type t
+
+val choice3 : 'a t -> 'b t -> 'c t -> [ `C1 of 'a | `C2 of 'b | `C3 of 'c ] t
+(** [choice3 s s' s''] allows for any of [s], [s'] or [s''].
+    In case of ambiguity (for instance pairs and lists can be ambiguous when
+    converting from opam values), the priority order is the order of
+    arguments. In other words if the data could be interpreted both as
+    [s] and [s'], it will be interpreted as [s].
+    Note that since cmdliner arguments have no particular structure
+    and everything is encoded as strings, you should always make string
+    the lowest priority. *)
+
+val from_opam_val :
+  'a t -> OpamParserTypes.FullPos.value -> ('a, Rresult.R.msg) result
+(** Deserialize from opam values *)
+
+val to_opam_val : 'a t -> 'a -> OpamParserTypes.FullPos.value
+(** Serialize into opam values *)
+
+val cmdliner_conv : 'a t -> 'a Cmdliner.Arg.conv
+(** Derive a Cmliner converter from a shape *)
+
+(**/**)
+
+(** Undocumented. Exposed for testing only *)
+
+val equal : 'a t -> 'a -> 'a -> bool
+val pp : 'a t -> 'a Fmt.t
+
+(**/**)

--- a/lib/source_opam_config.ml
+++ b/lib/source_opam_config.ml
@@ -51,8 +51,8 @@ module Make_field (X : FIELD_SHAPE) : FIELD with type t = X.t = struct
     let long_name = Printf.sprintf "add-%s" X.name in
     let doc =
       Printf.sprintf
-        "CLI equivalent of the %s extension. Use this to complement the \
-         corresponding extensions in your local opam files."
+        "CLI equivalent of the %s opam field. Use this to complement the \
+         corresponding fields in your local opam files."
         (Opam.Extra_field.name field)
     in
     Cmdliner.Arg.(opt (some cmdliner_conv) None (info ~doc ~docv [ long_name ]))
@@ -62,8 +62,8 @@ module Make_field (X : FIELD_SHAPE) : FIELD with type t = X.t = struct
     let long_name = X.name in
     let doc =
       Printf.sprintf
-        "CLI equivalent of the %s extension. Use this to replace the \
-         corresponding extensions in your local opam files."
+        "CLI equivalent of the %s opam field. Use this to replace the \
+         corresponding fields in your local opam files."
         (Opam.Extra_field.name field)
     in
     Cmdliner.Arg.(opt (some cmdliner_conv) None (info ~doc ~docv [ long_name ]))

--- a/lib/source_opam_config.ml
+++ b/lib/source_opam_config.ml
@@ -242,10 +242,7 @@ module Opam_repositories_url_rewriter = struct
   let rewrite_out ~opam_monorepo_cwd repositories_opt =
     match repositories_opt with
     | None -> None
-    | Some rs ->
-        let seq = OpamUrl.Set.to_seq rs in
-        let rewritten = Seq.map (rewrite_one_out ~opam_monorepo_cwd) seq in
-        Some (OpamUrl.Set.of_seq rewritten)
+    | Some rs -> Some (OpamUrl.Set.map (rewrite_one_out ~opam_monorepo_cwd) rs)
 end
 
 type t = {

--- a/lib/source_opam_config.ml
+++ b/lib/source_opam_config.ml
@@ -1,120 +1,94 @@
 open Import
 
-module Opam_repositories = struct
+module type FIELD_SHAPE = sig
+  type t
+
+  val name : string
+  val shape : t Serial_shape.t
+  val merge : t list -> (t, Rresult.R.msg) result
+end
+
+module type FIELD = sig
+  type t
+
+  val set : t -> OpamFile.OPAM.t -> OpamFile.OPAM.t
+  val get : OpamFile.OPAM.t -> (t option, Rresult.R.msg) result
+  val merge : t list -> (t, Rresult.R.msg) result
+
+  (**/**)
+
+  (** Exposed for testing purposes only *)
+
+  val from_opam_value :
+    OpamParserTypes.FullPos.value -> (t, Rresult.R.msg) result
+
+  val to_opam_value : t -> OpamParserTypes.FullPos.value
+
+  (**/**)
+end
+
+module Make_field (X : FIELD_SHAPE) : FIELD with type t = X.t = struct
+  type t = X.t
+
+  let to_opam_value t = Serial_shape.to_opam_val X.shape t
+  let from_opam_value value = Serial_shape.from_opam_val X.shape value
+
+  let field =
+    Opam.Extra_field.make ~name:X.name
+      ~to_opam_value:(Serial_shape.to_opam_val X.shape)
+      ~from_opam_value:(Serial_shape.from_opam_val X.shape)
+
+  let set t opam = Opam.Extra_field.set field t opam
+  let get opam = Opam.Extra_field.get field opam
+  let merge = X.merge
+end
+
+module Opam_repositories_shape = struct
   type t = OpamUrl.Set.t
 
-  let opam_monorepo_cwd_var = "$OPAM_MONOREPO_CWD"
+  let name = "opam-repositories"
 
-  let opam_monorepo_cwd_var_regexp =
-    let open Re in
-    compile (seq [ str "file://"; str opam_monorepo_cwd_var ])
+  let from_repr l =
+    let urls = List.map ~f:OpamUrl.of_string l in
+    Ok (OpamUrl.Set.of_list urls)
 
-  let rewrite_url_in ~pos ~opam_monorepo_cwd url_str =
-    let rewritten =
-      Re.replace_string opam_monorepo_cwd_var_regexp
-        ~by:("file://" ^ opam_monorepo_cwd)
-        url_str
-    in
-    if Astring.String.is_infix ~affix:opam_monorepo_cwd_var rewritten then
-      Opam.Pos.errorf ~pos
-        "$OPAM_MONOREPO_CWD can only be used to rewrite the root part of \
-         file:// URLs"
-    else Ok rewritten
+  let to_repr url_set =
+    OpamUrl.Set.elements url_set |> List.map ~f:OpamUrl.to_string
 
-  let rewrite_url_out ~opam_monorepo_cwd_regexp url_str =
-    Re.replace_string opam_monorepo_cwd_regexp
-      ~by:("file://" ^ opam_monorepo_cwd_var)
-      url_str
-
-  let url_from_opam_value ~opam_monorepo_cwd value =
-    let open Result.O in
-    let* url_string = Opam.Value.String.from_value value in
-    let pos = value.OpamParserTypes.FullPos.pos in
-    let* rewritten = rewrite_url_in ~pos ~opam_monorepo_cwd url_string in
-    Ok (OpamUrl.of_string rewritten)
-
-  let url_to_opam_value ~opam_monorepo_cwd_regexp url =
-    Opam.Value.String.to_value
-      (rewrite_url_out ~opam_monorepo_cwd_regexp (OpamUrl.to_string url))
-
-  let from_opam_value ~opam_monorepo_cwd value =
-    let open Result.O in
-    let+ l =
-      Opam.Value.List.from_value (url_from_opam_value ~opam_monorepo_cwd) value
-    in
-    OpamUrl.Set.of_list l
-
-  let to_opam_value ~opam_monorepo_cwd =
-    let opam_monorepo_cwd_regexp =
-      Re.(compile (seq [ str "file://"; str opam_monorepo_cwd ]))
-    in
-    fun t ->
-      let elements = OpamUrl.Set.elements t in
-      Opam.Value.List.to_value
-        (url_to_opam_value ~opam_monorepo_cwd_regexp)
-        elements
-
-  let field ~opam_monorepo_cwd =
-    Opam.Extra_field.make ~name:"opam-repositories"
-      ~from_opam_value:(from_opam_value ~opam_monorepo_cwd)
-      ~to_opam_value:(to_opam_value ~opam_monorepo_cwd)
-
-  let get ~opam_monorepo_cwd opam =
-    let field = field ~opam_monorepo_cwd in
-    Opam.Extra_field.get field opam
-
-  let set ~opam_monorepo_cwd t opam =
-    let field = field ~opam_monorepo_cwd in
-    Opam.Extra_field.set field t opam
+  let conv = Serial_shape.Conv.make ~from_repr ~to_repr ()
+  let shape = Serial_shape.conv conv Serial_shape.(list string)
 
   let merge = function
     | [] -> Ok OpamUrl.Set.empty
     | hd :: tl -> Ok (List.fold_left tl ~init:hd ~f:OpamUrl.Set.union)
 end
 
-module Opam_global_vars = struct
+module Opam_repositories = Make_field (Opam_repositories_shape)
+
+module Opam_global_vars_shape = struct
   type t = OpamVariable.variable_contents String.Map.t
+
+  let name = "global-opam-vars"
+
+  let var_content_from_repr choice =
+    match choice with
+    | `C1 b -> Ok (OpamVariable.B b)
+    | `C2 l -> Ok (OpamVariable.L l)
+    | `C3 s -> Ok (OpamVariable.S s)
+
+  let var_content_to_repr var =
+    match (var : OpamVariable.variable_contents) with
+    | B b -> `C1 b
+    | L l -> `C2 l
+    | S s -> `C3 s
+
+  let var_content_conv =
+    Serial_shape.Conv.make ~from_repr:var_content_from_repr
+      ~to_repr:var_content_to_repr ()
 
   exception Env_var_defined_twice of string
 
-  let variable_content_from_opam_value value =
-    let open Result.O in
-    match (value : OpamParserTypes.FullPos.value) with
-    | { pelem = Bool b; _ } -> Ok (OpamVariable.B b)
-    | { pelem = String s; _ } -> Ok (OpamVariable.S s)
-    | { pelem = List _; _ } ->
-        let+ l =
-          Opam.Value.List.from_value Opam.Value.String.from_value value
-        in
-        OpamVariable.L l
-    | _ ->
-        Opam.Pos.unexpected_value_error
-          ~expected:"a boolean, a string or list of strings" value
-
-  let variable_content_to_opam_value variable_content =
-    match (variable_content : OpamVariable.variable_contents) with
-    | B b -> Opam.Pos.with_default (OpamParserTypes.FullPos.Bool b)
-    | S s -> Opam.Value.String.to_value s
-    | L l -> Opam.Value.List.to_value Opam.Value.String.to_value l
-
-  let from_opam_value_one value =
-    let open Result.O in
-    let* l = Opam.Value.List.from_value Result.ok value in
-    match l with
-    | [ name; content ] ->
-        let* name = Opam.Value.String.from_value name in
-        let+ content = variable_content_from_opam_value content in
-        (name, content)
-    | _ ->
-        Opam.Pos.unexpected_value_error
-          ~expected:"a list with a var name followed by the var content" value
-
-  let to_opam_value_one (name, content) =
-    let name = Opam.Value.String.to_value name in
-    let content = variable_content_to_opam_value content in
-    Opam.Value.List.to_value Fun.id [ name; content ]
-
-  let from_bindings ~pos l =
+  let from_repr l =
     try
       List.fold_left l ~init:String.Map.empty ~f:(fun acc (name, content) ->
           String.Map.update acc name ~f:(function
@@ -122,24 +96,18 @@ module Opam_global_vars = struct
             | Some _ -> raise (Env_var_defined_twice name)))
       |> Result.ok
     with Env_var_defined_twice name ->
-      Opam.Pos.errorf ~pos "Env variable %s is defined more than once" name
+      Rresult.R.error_msgf "Opam global variable %s is defined more than once"
+        name
 
-  let from_opam_value value =
-    let open Result.O in
-    let pos = value.OpamParserTypes.FullPos.pos in
-    let* bindings = Opam.Value.List.from_value from_opam_value_one value in
-    from_bindings ~pos bindings
+  let to_repr map = String.Map.bindings map
+  let conv = Serial_shape.Conv.make ~from_repr ~to_repr ()
 
-  let to_opam_value t =
-    let bindings = String.Map.bindings t in
-    Opam.Value.List.to_value to_opam_value_one bindings
-
-  let field =
-    Opam.Extra_field.make ~name:"global-opam-vars" ~to_opam_value
-      ~from_opam_value
-
-  let get opam = Opam.Extra_field.get field opam
-  let set t opam = Opam.Extra_field.set field t opam
+  let shape =
+    let var_shape =
+      Serial_shape.conv var_content_conv
+        Serial_shape.(choice3 bool (list string) string)
+    in
+    Serial_shape.conv conv Serial_shape.(list (pair string var_shape))
 
   let merge = function
     | [] -> Ok String.Map.empty
@@ -153,50 +121,99 @@ module Opam_global_vars = struct
                   | Some c, Some c' when c = c' -> Some c
                   | Some _, Some _ -> raise (Env_var_defined_twice name)))
           |> Result.ok
-        with Env_var_defined_twice name ->
+        with Env_var_defined_twice var_name ->
           Rresult.R.error_msgf
             "Environment variable %s is set to different values in different \
              opam files %s field"
-            name
-            (Opam.Extra_field.name field))
+            var_name name)
 end
 
-module Opam_provided = struct
-  let from_opam_value opam_chunk =
-    let open Result.O in
-    let* names =
-      match (opam_chunk : OpamParserTypes.FullPos.value) with
-      | { pelem = String s; _ } -> Ok [ s ]
-      | { pelem = List items; _ } ->
-          items.pelem
-          |> List.map ~f:(fun item ->
-                 match (item : OpamParserTypes.FullPos.value) with
-                 | { pelem = String s; _ } -> Ok s
-                 | otherwise ->
-                     Opam.Pos.unexpected_value_error ~expected:"a string"
-                       otherwise)
-          |> Result.List.all
-      | otherwise ->
-          Opam.Pos.unexpected_value_error
-            ~expected:"a string or a list of strings" otherwise
-    in
-    let names = List.map ~f:OpamPackage.Name.of_string names in
-    Ok (OpamPackage.Name.Set.of_list names)
+module Opam_global_vars = Make_field (Opam_global_vars_shape)
 
-  let to_opam_value names =
-    OpamPackage.Name.Set.elements names
-    |> List.map ~f:OpamPackage.Name.to_string
-    |> Opam.Value.List.to_value Opam.Value.String.to_value
+module Opam_provided_shape = struct
+  type t = OpamPackage.Name.Set.t
 
-  let field =
-    Opam.Extra_field.make ~name:"opam-provided" ~to_opam_value ~from_opam_value
+  let name = "opam-provided"
 
-  let set t opam = Opam.Extra_field.set field t opam
-  let get opam = Opam.Extra_field.get field opam
+  let from_repr repr =
+    let l = match repr with `C1 l -> l | `C2 s -> [ s ] in
+    l
+    |> List.map ~f:OpamPackage.Name.of_string
+    |> OpamPackage.Name.Set.of_list |> Result.ok
+
+  let to_repr t =
+    t |> OpamPackage.Name.Set.elements |> List.map ~f:OpamPackage.Name.to_string
+    |> fun l -> `C1 l
+
+  let conv = Serial_shape.Conv.make ~from_repr ~to_repr ()
+  let shape = Serial_shape.conv conv Serial_shape.(choice2 (list string) string)
 
   let merge = function
     | [] -> Ok OpamPackage.Name.Set.empty
     | init :: xs -> Ok (List.fold_left xs ~init ~f:OpamPackage.Name.Set.union)
+end
+
+module Opam_provided = Make_field (Opam_provided_shape)
+
+module Opam_repositories_url_rewriter = struct
+  let opam_monorepo_cwd_var = "$OPAM_MONOREPO_CWD"
+  let opam_monorepo_cwd_var_len = String.length opam_monorepo_cwd_var
+
+  let rewrite_one_in ~opam_monorepo_cwd url =
+    let error () =
+      Rresult.R.error_msgf
+        "$OPAM_MONOREPO_CWD can only be used to rewrite the root part of \
+         file:// URLs. %S is an invalid use of the variable."
+        (OpamUrl.to_string url)
+    in
+    let idx =
+      Astring.String.find_sub ~start:0 ~sub:opam_monorepo_cwd_var
+        url.OpamUrl.path
+    in
+    match ((url : OpamUrl.t), idx) with
+    | { transport = "file"; path; _ }, Some 0 ->
+        let path_remainder =
+          String.sub ~pos:opam_monorepo_cwd_var_len
+            ~len:(String.length path - opam_monorepo_cwd_var_len)
+            path
+        in
+        let rewritten_path = opam_monorepo_cwd ^ path_remainder in
+        Ok { url with OpamUrl.path = rewritten_path }
+    | { transport = _; _ }, Some _ -> error ()
+    | _, None -> Ok url
+
+  let rewrite_one_out ~opam_monorepo_cwd url =
+    match url.OpamUrl.transport with
+    | "file" -> (
+        let path_remainder =
+          String.drop_prefix ~prefix:opam_monorepo_cwd url.OpamUrl.path
+        in
+        match path_remainder with
+        | Some r ->
+            let rewritten_path = opam_monorepo_cwd_var ^ r in
+            { url with OpamUrl.path = rewritten_path }
+        | None -> url)
+    | _ -> url
+
+  let rewrite_in ~opam_monorepo_cwd repositories_opt =
+    let open Result.O in
+    match repositories_opt with
+    | None -> Ok None
+    | Some rs ->
+        let l = OpamUrl.Set.elements rs in
+        let* rewritten =
+          Result.List.map ~f:(rewrite_one_in ~opam_monorepo_cwd) l
+        in
+        let set = OpamUrl.Set.of_list rewritten in
+        Ok (Some set)
+
+  let rewrite_out ~opam_monorepo_cwd repositories_opt =
+    match repositories_opt with
+    | None -> None
+    | Some rs ->
+        let seq = OpamUrl.Set.to_seq rs in
+        let rewritten = Seq.map (rewrite_one_out ~opam_monorepo_cwd) seq in
+        Some (OpamUrl.Set.of_seq rewritten)
 end
 
 type t = {
@@ -214,8 +231,11 @@ let get ~opam_monorepo_cwd opam_file =
   let open Result.O in
   let opam_monorepo_cwd = opam_monorepo_cwd_from_root opam_monorepo_cwd in
   let* global_vars = Opam_global_vars.get opam_file in
-  let* repositories = Opam_repositories.get ~opam_monorepo_cwd opam_file in
+  let* repositories = Opam_repositories.get opam_file in
   let* opam_provided = Opam_provided.get opam_file in
+  let* repositories =
+    Opam_repositories_url_rewriter.rewrite_in ~opam_monorepo_cwd repositories
+  in
   Ok { global_vars; repositories; opam_provided }
 
 let set_field set var opam_file =
@@ -224,9 +244,12 @@ let set_field set var opam_file =
 let set ~opam_monorepo_cwd { global_vars; repositories; opam_provided }
     opam_file =
   let opam_monorepo_cwd = opam_monorepo_cwd_from_root opam_monorepo_cwd in
+  let repositories =
+    Opam_repositories_url_rewriter.rewrite_out ~opam_monorepo_cwd repositories
+  in
   opam_file
   |> set_field Opam_global_vars.set global_vars
-  |> set_field (Opam_repositories.set ~opam_monorepo_cwd) repositories
+  |> set_field Opam_repositories.set repositories
   |> set_field Opam_provided.set opam_provided
 
 let merge_field f a b =
@@ -267,5 +290,15 @@ module Private = struct
   module Opam_global_vars = struct
     let from_opam_value = Opam_global_vars.from_opam_value
     let to_opam_value = Opam_global_vars.to_opam_value
+  end
+
+  module Opam_provided = struct
+    let from_opam_value = Opam_provided.from_opam_value
+    let to_opam_value = Opam_provided.to_opam_value
+  end
+
+  module Opam_repositories_url_rewriter = struct
+    let rewrite_one_in = Opam_repositories_url_rewriter.rewrite_one_in
+    let rewrite_one_out = Opam_repositories_url_rewriter.rewrite_one_out
   end
 end

--- a/lib/source_opam_config.mli
+++ b/lib/source_opam_config.mli
@@ -45,6 +45,7 @@ val cli_overwrite_config : t Cmdliner.Term.t
     extracted from opam files. *)
 
 val make :
+  opam_monorepo_cwd:Fpath.t ->
   overwrite_config:t ->
   add_config:t ->
   local_opam_files_config:t ->

--- a/lib/source_opam_config.mli
+++ b/lib/source_opam_config.mli
@@ -36,18 +36,17 @@ val set : opam_monorepo_cwd:Fpath.t -> t -> OpamFile.OPAM.t -> OpamFile.OPAM.t
 val merge : t list -> (t, Rresult.R.msg) result
 (** Merges config from different opam files into a single, shared config. *)
 
-val cli_add_config : t Cmdliner.Term.t
-(** Set of CLI options used to build a complementatry config to be merged
-    with into the config extracted from opam files. *)
+type adjustment
+(** Type of configuration adjustment.
+    Defines values to overwrite fields of a configuration and values
+    to merge into existing fields. *)
 
-val cli_overwrite_config : t Cmdliner.Term.t
-(** Set of CLI options used to build a config to use in place of the one
-    extracted from opam files. *)
+val cli_adjustment : adjustment Cmdliner.Term.t
+(** Set of CLI options used to overwrite or complement fields of a config. *)
 
 val make :
   opam_monorepo_cwd:Fpath.t ->
-  overwrite_config:t ->
-  add_config:t ->
+  adjustment:adjustment ->
   local_opam_files_config:t ->
   (t, Rresult.R.msg) result
 (** Assembles the final config by properly combining all sources.

--- a/lib/source_opam_config.mli
+++ b/lib/source_opam_config.mli
@@ -45,22 +45,35 @@ module Private : sig
       DO NOT USE! *)
   module Opam_repositories : sig
     val from_opam_value :
-      opam_monorepo_cwd:string ->
       OpamParserTypes.FullPos.value ->
       (OpamUrl.Set.t, [ `Msg of string ]) result
 
-    val to_opam_value :
-      opam_monorepo_cwd:string -> OpamUrl.Set.t -> OpamParserTypes.FullPos.value
+    val to_opam_value : OpamUrl.Set.t -> OpamParserTypes.FullPos.value
   end
 
   module Opam_global_vars : sig
     val from_opam_value :
       OpamParserTypes.FullPos.value ->
-      (OpamVariable.variable_contents String.Map.t, [ `Msg of string ]) result
+      (OpamVariable.variable_contents String.Map.t, Rresult.R.msg) result
 
     val to_opam_value :
       OpamVariable.variable_contents String.Map.t ->
       OpamParserTypes.FullPos.value
+  end
+
+  module Opam_provided : sig
+    val from_opam_value :
+      OpamParserTypes.FullPos.value ->
+      (OpamPackage.Name.Set.t, Rresult.R.msg) result
+
+    val to_opam_value : OpamPackage.Name.Set.t -> OpamParserTypes.FullPos.value
+  end
+
+  module Opam_repositories_url_rewriter : sig
+    val rewrite_one_in :
+      opam_monorepo_cwd:string -> OpamUrl.t -> (OpamUrl.t, Rresult.R.msg) result
+
+    val rewrite_one_out : opam_monorepo_cwd:string -> OpamUrl.t -> OpamUrl.t
   end
 end
 

--- a/lib/source_opam_config.mli
+++ b/lib/source_opam_config.mli
@@ -36,6 +36,25 @@ val set : opam_monorepo_cwd:Fpath.t -> t -> OpamFile.OPAM.t -> OpamFile.OPAM.t
 val merge : t list -> (t, Rresult.R.msg) result
 (** Merges config from different opam files into a single, shared config. *)
 
+val cli_add_config : t Cmdliner.Term.t
+(** Set of CLI options used to build a complementatry config to be merged
+    with into the config extracted from opam files. *)
+
+val cli_overwrite_config : t Cmdliner.Term.t
+(** Set of CLI options used to build a config to use in place of the one
+    extracted from opam files. *)
+
+val make :
+  overwrite_config:t ->
+  add_config:t ->
+  local_opam_files_config:t ->
+  (t, Rresult.R.msg) result
+(** Assembles the final config by properly combining all sources.
+    If a field is defined (i.e. is not [None]) in [overwrite_config],
+    its value will be used, ignoring the field value from both other sources.
+    If it is not, the combined value of [add_config] and
+    [local_opam_files_config] will be used. *)
+
 (**/**)
 
 (** Undocumented *)
@@ -49,6 +68,7 @@ module Private : sig
       (OpamUrl.Set.t, [ `Msg of string ]) result
 
     val to_opam_value : OpamUrl.Set.t -> OpamParserTypes.FullPos.value
+    val cmdliner_conv : OpamUrl.Set.t Cmdliner.Arg.conv
   end
 
   module Opam_global_vars : sig
@@ -59,6 +79,9 @@ module Private : sig
     val to_opam_value :
       OpamVariable.variable_contents String.Map.t ->
       OpamParserTypes.FullPos.value
+
+    val cmdliner_conv :
+      OpamVariable.variable_contents String.Map.t Cmdliner.Arg.conv
   end
 
   module Opam_provided : sig
@@ -67,6 +90,7 @@ module Private : sig
       (OpamPackage.Name.Set.t, Rresult.R.msg) result
 
     val to_opam_value : OpamPackage.Name.Set.t -> OpamParserTypes.FullPos.value
+    val cmdliner_conv : OpamPackage.Name.Set.t Cmdliner.Arg.conv
   end
 
   module Opam_repositories_url_rewriter : sig

--- a/test/bin/config-cli-args.t/repo/packages/b/b.1/opam
+++ b/test/bin/config-cli-args.t/repo/packages/b/b.1/opam
@@ -1,0 +1,11 @@
+opam-version: "2.0"
+depends: [
+  "dune"
+]
+dev-repo: "git+https://github.com/b/b"
+url {
+  src: "https://b.com/b.tbz"
+  checksum: [
+    "sha256=0000000000000000000000000000000000000000000000000000000000000000"
+  ]
+}

--- a/test/bin/config-cli-args.t/repo/packages/c/c.1/opam
+++ b/test/bin/config-cli-args.t/repo/packages/c/c.1/opam
@@ -1,0 +1,11 @@
+opam-version: "2.0"
+depends: [
+  "dune"
+]
+dev-repo: "git+https://github.com/c/c"
+url {
+  src: "https://c.com/c.tbz"
+  checksum: [
+    "sha256=0000000000000000000000000000000000000000000000000000000000000001"
+  ]
+}

--- a/test/bin/config-cli-args.t/repo/repo
+++ b/test/bin/config-cli-args.t/repo/repo
@@ -1,0 +1,1 @@
+opam-version: "2.0"

--- a/test/bin/config-cli-args.t/run.t
+++ b/test/bin/config-cli-args.t/run.t
@@ -1,0 +1,61 @@
+We have a local package 'config-cli-args' that has the following
+opam file:
+
+  $ cat > config-cli-args.opam << EOF
+  > opam-version: "2.0"
+  > depends: [
+  >   "dune"
+  >   "b"
+  >   "c"
+  > ]
+  > EOF
+
+It needs to use two local repositories for 'lock' to be successful.
+The minimal repo that we generate here:
+
+  $ gen-minimal-repo
+
+that contains 'dune' but also the locally defined repo that contains
+'b' and 'c'.
+At the moment it has no 'x-opam-monorepo-opam-repositories' extension set.
+We can use the '--opam-repositories' option to set it via the command line:
+
+  $ opam-monorepo lock --opam-repositories '[file://$OPAM_MONOREPO_CWD/minimal-repo,file://$OPAM_MONOREPO_CWD/repo]' > /dev/null
+  $ opam show --just-file -fx-opam-monorepo-opam-repositories ./config-cli-args.opam.locked
+  file://$OPAM_MONOREPO_CWD/minimal-repo, file://$OPAM_MONOREPO_CWD/repo
+
+We can see from the generated lock file that it used the set of repos we provided on
+the command line.
+
+Now we can also use the '--add-opam-repositories' option to complement the local
+opam extensions.
+
+  $ echo 'x-opam-monorepo-opam-repositories: ["file://$OPAM_MONOREPO_CWD/minimal-repo"]' >> ./config-cli-args.opam
+  $ opam show --just-file -fx-opam-monorepo-opam-repositories ./config-cli-args.opam
+  file://$OPAM_MONOREPO_CWD/minimal-repo
+
+Here we just added one of the two repos to our opam file. We can tell the solver
+to use an additional one by invoking:
+
+  $ rm ./config-cli-args.opam.locked
+  $ opam-monorepo lock --add-opam-repositories '[file://$OPAM_MONOREPO_CWD/repo]' > /dev/null
+  $ opam show --just-file -fx-opam-monorepo-opam-repositories ./config-cli-args.opam.locked
+  file://$OPAM_MONOREPO_CWD/minimal-repo, file://$OPAM_MONOREPO_CWD/repo
+
+Once again, we can see from the generated lock file that it used both repos.
+
+Note that you can use the '--opam-repositories' option to overwrite any local
+extension.
+
+  $ sed -i '$d' ./config-cli-args.opam
+  $ echo 'x-opam-monorepo-opam-repositories: ["https://a.com/a.tbz"]' >> ./config-cli-args.opam
+  $ opam show --just-file -fx-opam-monorepo-opam-repositories ./config-cli-args.opam
+  https://a.com/a.tbz
+
+Here we replaced our opam-repositories to point to 'https://a.com/a.tbz'. We
+can once again use '--opam-repositories' as in our first 'lock' attempt to
+overwrite that and use the proper repositories instead:
+
+  $ opam-monorepo lock --opam-repositories '[file://$OPAM_MONOREPO_CWD/minimal-repo,file://$OPAM_MONOREPO_CWD/repo]' > /dev/null
+  $ opam show --just-file -fx-opam-monorepo-opam-repositories ./config-cli-args.opam.locked
+  file://$OPAM_MONOREPO_CWD/minimal-repo, file://$OPAM_MONOREPO_CWD/repo

--- a/test/bin/opam-provided.t/run.t
+++ b/test/bin/opam-provided.t/run.t
@@ -115,26 +115,6 @@ Since it is, we need to make its dependency, "b", also `opam`-provided.
   "ocaml-config" {= "2"}
   "ocaml-options-vanilla" {= "1"}
 
-Since we add a new custom stanza to the Opam file, let's make sure we emit
-warnings when things are specified the wrong way, e.g., if the package to
-be ignored is not a string.
-
-  $ opam show --just-file --raw -fx-opam-monorepo-opam-provided ./warning.opam
-  42
-
-  $ opam-monorepo lock warning > /dev/null
-  opam-monorepo: [ERROR] Error in opam file $TESTCASE_ROOT/warning.opam, [8:31]-[8:33]: Expected a string or a list of strings, got: 42
-  [1]
-
-Similarly, we accept a list but it needs to be a list of strings which this is
-not:
-
-  $ opam show --just-file --raw -fx-opam-monorepo-opam-provided ./warning-list.opam
-  42 "fourtytwo"
-  $ opam-monorepo lock warning > /dev/null
-  opam-monorepo: [ERROR] Error in opam file $TESTCASE_ROOT/warning.opam, [8:31]-[8:33]: Expected a string or a list of strings, got: 42
-  [1]
-
 It should also work to pass the version of the compiler and be respected for
 both `opam`-provided packages as well as those to be vendored:
 

--- a/test/lib/test_duniverse_lib.ml
+++ b/test/lib/test_duniverse_lib.ml
@@ -8,6 +8,7 @@ let () =
       Test_opam.suite;
       Test_parallel.suite;
       Test_pin_depends.suite;
+      Test_serial_shape.suite;
       Test_source_opam_config.suite;
       Test_uri_utils.suite;
     ]

--- a/test/lib/test_serial_shape.ml
+++ b/test/lib/test_serial_shape.ml
@@ -129,15 +129,16 @@ let test_cmdliner_parse =
     make_test ~name:"pair"
       ~shape:Serial_shape.(pair bool string)
       ~expected:(Ok (true, "abc"))
-      ~value:"true,abc";
+      ~value:"[true,abc]";
     make_test ~name:"list"
       ~shape:Serial_shape.(list bool)
       ~expected:(Ok [ true; false; true ])
-      ~value:"true,false,true";
-    make_test ~name:"list with delim"
-      ~shape:Serial_shape.(list bool)
-      ~expected:(Ok [ true; false; true ])
       ~value:"[true,false,true]";
+    make_test ~name:"list without delim"
+      ~shape:Serial_shape.(list bool)
+      ~expected:
+        (Rresult.R.error_msg "list or pairs must be delimited by '[' and ']'")
+      ~value:"true,false,true";
     make_test ~name:"choice c1"
       ~shape:Serial_shape.(choice3 bool (list bool) string)
       ~expected:(Ok (`C1 true))
@@ -145,7 +146,7 @@ let test_cmdliner_parse =
     make_test ~name:"choice c2"
       ~shape:Serial_shape.(choice3 bool (list bool) string)
       ~expected:(Ok (`C2 [ true; false ]))
-      ~value:"true,false";
+      ~value:"[true,false]";
     make_test ~name:"choice c3"
       ~shape:Serial_shape.(choice3 bool (list bool) string)
       ~expected:(Ok (`C3 "abc"))
@@ -153,15 +154,15 @@ let test_cmdliner_parse =
     make_test ~name:"ambiguous choice"
       ~shape:Serial_shape.(choice3 bool (pair bool bool) (list bool))
       ~expected:(Ok (`C2 (true, false)))
-      ~value:"true,false";
+      ~value:"[true,false]";
     make_test ~name:"ambiguous choice 2"
       ~shape:Serial_shape.(choice3 bool (list bool) (pair bool bool))
       ~expected:(Ok (`C2 [ true; false ]))
-      ~value:"true,false";
+      ~value:"[true,false]";
     make_test ~name:"list within list"
       ~shape:Serial_shape.(list (list bool))
       ~expected:(Ok [ [ true ]; [ true; false ]; [ false ] ])
-      ~value:"true,[true,false],false";
+      ~value:"[[true],[true,false],[false]]";
     make_test ~name:"empty list"
       ~shape:Serial_shape.(list bool)
       ~expected:(Ok []) ~value:"";
@@ -172,11 +173,11 @@ let test_cmdliner_parse =
     make_test ~name:"unterminated inner list"
       ~shape:Serial_shape.(list (list string))
       ~expected:(Error (`Msg "unmatched list delimiter '['"))
-      ~value:"[abc,def],[uvw,xyz";
+      ~value:"[[abc,def],[uvw,xyz,[rst]]";
     make_test ~name:"floating ]"
       ~shape:Serial_shape.(list string)
       ~expected:(Error (`Msg "unmatched list delimiter ']'"))
-      ~value:"abc,def]";
+      ~value:"[abc,def]]";
     make_test ~name:"conv"
       ~shape:Serial_shape.(conv int_as_string_conv string)
       ~expected:(Ok 123) ~value:"123";

--- a/test/lib/test_serial_shape.ml
+++ b/test/lib/test_serial_shape.ml
@@ -1,0 +1,227 @@
+open Duniverse_lib
+open Import
+
+let shape_testable shape =
+  Alcotest.testable (Serial_shape.pp shape) (Serial_shape.equal shape)
+
+let int_as_string_conv =
+  Serial_shape.Conv.make
+    ~from_repr:(fun s ->
+      match int_of_string_opt s with
+      | Some i -> Ok i
+      | None -> Rresult.R.error_msgf "Expected an int but got %s" s)
+    ~to_repr:Int.to_string ~equal:Int.equal ~pp:Fmt.int ()
+
+let test_from_opam_val =
+  let make_test :
+      type a.
+      name:string ->
+      shape:a Serial_shape.t ->
+      expected:(a, Rresult.R.msg) result ->
+      value:string ->
+      unit Alcotest.test_case =
+   fun ~name ~shape ~expected ~value ->
+    let test_name = Printf.sprintf "Serial_shape.from_opam_val: %s" name in
+    let test_fun () =
+      let value = OpamParser.FullPos.value_from_string value "test.opam" in
+      let actual = Serial_shape.from_opam_val shape value in
+      Alcotest.(check (result (shape_testable shape) Testable.r_msg))
+        test_name expected actual
+    in
+    (test_name, `Quick, test_fun)
+  in
+  [
+    make_test ~name:"bool" ~shape:Serial_shape.bool ~expected:(Ok true)
+      ~value:{|true|};
+    make_test ~name:"string" ~shape:Serial_shape.string ~expected:(Ok "abc")
+      ~value:{|"abc"|};
+    make_test ~name:"pair"
+      ~shape:Serial_shape.(pair bool string)
+      ~expected:(Ok (true, "abc"))
+      ~value:{|[true "abc"]|};
+    make_test ~name:"list"
+      ~shape:Serial_shape.(list bool)
+      ~expected:(Ok [ true; false; true ])
+      ~value:{|[true false true]|};
+    make_test ~name:"conv"
+      ~shape:Serial_shape.(conv int_as_string_conv string)
+      ~expected:(Ok 123) ~value:{|"123"|};
+    make_test ~name:"choice c1"
+      ~shape:Serial_shape.(choice3 bool string (list string))
+      ~expected:(Ok (`C1 true))
+      ~value:{|true|};
+    make_test ~name:"choice c2"
+      ~shape:Serial_shape.(choice3 bool string (list string))
+      ~expected:(Ok (`C2 "abc"))
+      ~value:{|"abc"|};
+    make_test ~name:"choice c3"
+      ~shape:Serial_shape.(choice3 bool string (list string))
+      ~expected:(Ok (`C3 [ "abc"; "def" ]))
+      ~value:{|["abc" "def"]|};
+    make_test ~name:"ambiguous choice"
+      ~shape:Serial_shape.(choice3 (pair string string) (list string) bool)
+      ~expected:(Ok (`C1 ("abc", "def")))
+      ~value:{|["abc" "def"]|};
+    make_test ~name:"ambiguous choice 2"
+      ~shape:Serial_shape.(choice3 (list string) (pair string string) bool)
+      ~expected:(Ok (`C1 [ "abc"; "def" ]))
+      ~value:{|["abc" "def"]|};
+  ]
+
+let test_to_opam_val =
+  let make_test :
+      type a.
+      name:string ->
+      shape:a Serial_shape.t ->
+      expected:string ->
+      value:a ->
+      unit Alcotest.test_case =
+   fun ~name ~shape ~expected ~value ->
+    let test_name = Printf.sprintf "Serial_shape.to_opam_val: %s" name in
+    let test_fun () =
+      let actual = Serial_shape.to_opam_val shape value in
+      let actual = OpamPrinter.FullPos.value actual in
+      Alcotest.(check string) test_name expected actual
+    in
+    (test_name, `Quick, test_fun)
+  in
+  [
+    make_test ~name:"bool" ~shape:Serial_shape.bool ~expected:{|true|}
+      ~value:true;
+    make_test ~name:"string" ~shape:Serial_shape.string ~expected:{|"abc"|}
+      ~value:"abc";
+    make_test ~name:"pair"
+      ~shape:Serial_shape.(pair bool string)
+      ~expected:{|[true "abc"]|} ~value:(true, "abc");
+    make_test ~name:"list"
+      ~shape:Serial_shape.(list bool)
+      ~expected:{|[true false true]|} ~value:[ true; false; true ];
+    make_test ~name:"conv"
+      ~shape:Serial_shape.(conv int_as_string_conv string)
+      ~expected:{|"123"|} ~value:123;
+  ]
+
+let test_cmdliner_parse =
+  let make_test :
+      type a.
+      name:string ->
+      shape:a Serial_shape.t ->
+      expected:(a, Rresult.R.msg) result ->
+      value:string ->
+      unit Alcotest.test_case =
+   fun ~name ~shape ~expected ~value ->
+    let test_name =
+      Printf.sprintf "Serial_shape.cmdliner_conv: parse %s" name
+    in
+    let test_fun () =
+      let conv = Serial_shape.cmdliner_conv shape in
+      let actual = (Cmdliner.Arg.conv_parser conv) value in
+      Alcotest.(check (result (shape_testable shape) Testable.r_msg))
+        test_name expected actual
+    in
+    (test_name, `Quick, test_fun)
+  in
+  [
+    make_test ~name:"bool" ~shape:Serial_shape.bool ~expected:(Ok true)
+      ~value:"true";
+    make_test ~name:"string" ~shape:Serial_shape.string ~expected:(Ok "abc")
+      ~value:"abc";
+    make_test ~name:"pair"
+      ~shape:Serial_shape.(pair bool string)
+      ~expected:(Ok (true, "abc"))
+      ~value:"true,abc";
+    make_test ~name:"list"
+      ~shape:Serial_shape.(list bool)
+      ~expected:(Ok [ true; false; true ])
+      ~value:"true,false,true";
+    make_test ~name:"list with delim"
+      ~shape:Serial_shape.(list bool)
+      ~expected:(Ok [ true; false; true ])
+      ~value:"[true,false,true]";
+    make_test ~name:"choice c1"
+      ~shape:Serial_shape.(choice3 bool (list bool) string)
+      ~expected:(Ok (`C1 true))
+      ~value:"true";
+    make_test ~name:"choice c2"
+      ~shape:Serial_shape.(choice3 bool (list bool) string)
+      ~expected:(Ok (`C2 [ true; false ]))
+      ~value:"true,false";
+    make_test ~name:"choice c3"
+      ~shape:Serial_shape.(choice3 bool (list bool) string)
+      ~expected:(Ok (`C3 "abc"))
+      ~value:"abc";
+    make_test ~name:"ambiguous choice"
+      ~shape:Serial_shape.(choice3 bool (pair bool bool) (list bool))
+      ~expected:(Ok (`C2 (true, false)))
+      ~value:"true,false";
+    make_test ~name:"ambiguous choice 2"
+      ~shape:Serial_shape.(choice3 bool (list bool) (pair bool bool))
+      ~expected:(Ok (`C2 [ true; false ]))
+      ~value:"true,false";
+    make_test ~name:"list within list"
+      ~shape:Serial_shape.(list (list bool))
+      ~expected:(Ok [ [ true ]; [ true; false ]; [ false ] ])
+      ~value:"true,[true,false],false";
+    make_test ~name:"empty list"
+      ~shape:Serial_shape.(list bool)
+      ~expected:(Ok []) ~value:"";
+    make_test ~name:"unterminated list"
+      ~shape:Serial_shape.(list string)
+      ~expected:(Error (`Msg "unmatched list delimiter '['"))
+      ~value:"[abc,def";
+    make_test ~name:"unterminated inner list"
+      ~shape:Serial_shape.(list (list string))
+      ~expected:(Error (`Msg "unmatched list delimiter '['"))
+      ~value:"[abc,def],[uvw,xyz";
+    make_test ~name:"floating ]"
+      ~shape:Serial_shape.(list string)
+      ~expected:(Error (`Msg "unmatched list delimiter ']'"))
+      ~value:"abc,def]";
+    make_test ~name:"conv"
+      ~shape:Serial_shape.(conv int_as_string_conv string)
+      ~expected:(Ok 123) ~value:"123";
+  ]
+
+let test_cmdliner_print =
+  let make_test :
+      type a.
+      name:string ->
+      shape:a Serial_shape.t ->
+      value:a ->
+      expected:string ->
+      unit Alcotest.test_case =
+   fun ~name ~shape ~value ~expected ->
+    let test_name =
+      Printf.sprintf "Serial_shape.cmdliner_conv: print %s" name
+    in
+    let test_fun () =
+      let conv = Serial_shape.cmdliner_conv shape in
+      let actual = Fmt.str "%a" (Cmdliner.Arg.conv_printer conv) value in
+      Alcotest.(check string) test_name expected actual
+    in
+    (test_name, `Quick, test_fun)
+  in
+  [
+    make_test ~name:"bool" ~shape:Serial_shape.bool ~expected:"true" ~value:true;
+    make_test ~name:"string" ~shape:Serial_shape.string ~expected:"abc"
+      ~value:"abc";
+    make_test ~name:"pair"
+      ~shape:Serial_shape.(pair bool string)
+      ~expected:"[true,abc]" ~value:(true, "abc");
+    make_test ~name:"list"
+      ~shape:Serial_shape.(list bool)
+      ~expected:"[true,false,true]" ~value:[ true; false; true ];
+    make_test ~name:"conv"
+      ~shape:Serial_shape.(conv int_as_string_conv string)
+      ~expected:"123" ~value:123;
+  ]
+
+let suite =
+  ( "Serial_shape",
+    List.concat
+      [
+        test_from_opam_val;
+        test_to_opam_val;
+        test_cmdliner_parse;
+        test_cmdliner_print;
+      ] )

--- a/test/lib/test_serial_shape.ml
+++ b/test/lib/test_serial_shape.ml
@@ -62,7 +62,7 @@ let test_from_opam_val =
       ~shape:Serial_shape.(choice3 (pair string string) (list string) bool)
       ~expected:(Ok (`C1 ("abc", "def")))
       ~value:{|["abc" "def"]|};
-    make_test ~name:"ambiguous choice 2"
+    make_test ~name:"ambiguous choice with swapped priorities"
       ~shape:Serial_shape.(choice3 (list string) (pair string string) bool)
       ~expected:(Ok (`C1 [ "abc"; "def" ]))
       ~value:{|["abc" "def"]|};

--- a/test/lib/test_serial_shape.ml
+++ b/test/lib/test_serial_shape.ml
@@ -115,7 +115,7 @@ let test_cmdliner_parse =
     in
     let test_fun () =
       let conv = Serial_shape.cmdliner_conv shape in
-      let actual = (Cmdliner.Arg.conv_parser conv) value in
+      let actual = Cmdliner.Arg.conv_parser conv value in
       Alcotest.(check (result (shape_testable shape) Testable.r_msg))
         test_name expected actual
     in

--- a/test/lib/test_serial_shape.mli
+++ b/test/lib/test_serial_shape.mli
@@ -1,0 +1,1 @@
+val suite : string * unit Alcotest.test_case list

--- a/test/lib/test_source_opam_config.ml
+++ b/test/lib/test_source_opam_config.ml
@@ -176,9 +176,9 @@ module Opam_repositories = struct
       (test_name, `Quick, test_fun)
     in
     [
-      make_test ~name:"Simple" ~value:"https://a.com"
+      make_test ~name:"Simple" ~value:"[https://a.com]"
         ~expected:(Ok [ "https://a.com" ]);
-      make_test ~name:"Simple" ~value:"https://a.com,https://b.com"
+      make_test ~name:"Simple" ~value:"[https://a.com,https://b.com]"
         ~expected:(Ok [ "https://a.com"; "https://b.com" ]);
     ]
 end
@@ -259,8 +259,7 @@ module Opam_global_vars = struct
         ~expected:(Ok [ ("var1", B true) ]);
       make_test ~name:"Multiple" ~value:"[[var1,true],[var2,a],[var3,[a,b]]]"
         ~expected:
-          (Ok
-             [ ("var1", B true); ("var2", L [ "a" ]); ("var3", L [ "a"; "b" ]) ]);
+          (Ok [ ("var1", B true); ("var2", S "a"); ("var3", L [ "a"; "b" ]) ]);
     ]
 end
 

--- a/test/lib/test_source_opam_config.ml
+++ b/test/lib/test_source_opam_config.ml
@@ -1,4 +1,5 @@
-open Duniverse_lib.Import
+open Duniverse_lib
+open Import
 
 let opam_url_set =
   let pp fmt url_set =
@@ -8,6 +9,17 @@ let opam_url_set =
       elements
   in
   Alcotest.testable pp OpamUrl.Set.equal
+
+let pkg_name_set =
+  let pp_one fmt pkg_name =
+    Fmt.pf fmt "%S" (OpamPackage.Name.to_string pkg_name)
+  in
+  let pp fmt set =
+    Fmt.pf fmt "[%a]"
+      Fmt.(list ~sep:(const char ';') pp_one)
+      (OpamPackage.Name.Set.elements set)
+  in
+  Alcotest.testable pp OpamPackage.Name.Set.equal
 
 let variable_content_string_map =
   let equal = String.Map.equal ~cmp:( = ) in
@@ -21,9 +33,84 @@ let variable_content_string_map =
   in
   Alcotest.testable pp equal
 
+module Opam_repositories_url_rewriter = struct
+  let test_rewrite_one_in =
+    let make_test ~name ~opam_monorepo_cwd ~value ~expected =
+      let test_name =
+        Printf.sprintf "Opam_repositories_url_rewriter.rewrite_one_in: %s" name
+      in
+      let test_fun () =
+        let open Source_opam_config.Private in
+        let value = OpamUrl.of_string value in
+        let actual =
+          Opam_repositories_url_rewriter.rewrite_one_in ~opam_monorepo_cwd value
+          |> Result.map ~f:OpamUrl.to_string
+        in
+        Alcotest.(check (result string Testable.r_msg))
+          test_name expected actual
+      in
+      (test_name, `Quick, test_fun)
+    in
+    [
+      make_test ~name:"Rewrites root" ~opam_monorepo_cwd:"/home/a"
+        ~value:"file://$OPAM_MONOREPO_CWD/something_local"
+        ~expected:(Ok "file:///home/a/something_local");
+      make_test ~name:"Rewrites vcs root" ~opam_monorepo_cwd:"/home/a"
+        ~value:"git+file://$OPAM_MONOREPO_CWD/something_local"
+        ~expected:(Ok "git+file:///home/a/something_local");
+      make_test ~name:"Does not rewrite remote" ~opam_monorepo_cwd:"/home/a"
+        ~value:"https://$OPAM_MONOREPO_CWD/something_local"
+        ~expected:
+          (Rresult.R.error_msg
+             "$OPAM_MONOREPO_CWD can only be used to rewrite the root part of \
+              file:// URLs. \"https://$OPAM_MONOREPO_CWD/something_local\" is \
+              an invalid use of the variable.");
+      make_test ~name:"Does not rewrite non root" ~opam_monorepo_cwd:"/home/a"
+        ~value:"file:///home/$OPAM_MONOREPO_CWD/something_local"
+        ~expected:
+          (Rresult.R.error_msg
+             "$OPAM_MONOREPO_CWD can only be used to rewrite the root part of \
+              file:// URLs. \
+              \"file:///home/$OPAM_MONOREPO_CWD/something_local\" is an \
+              invalid use of the variable.");
+    ]
+
+  let test_rewrite_one_out =
+    let make_test ~name ~opam_monorepo_cwd ~expected ~value =
+      let test_name =
+        Printf.sprintf "Opam_repositories_url_rewriter.rewrite_one_out: %s" name
+      in
+      let test_fun () =
+        let open Source_opam_config.Private in
+        let value = OpamUrl.of_string value in
+        let actual =
+          Opam_repositories_url_rewriter.rewrite_one_out ~opam_monorepo_cwd
+            value
+          |> OpamUrl.to_string
+        in
+        Alcotest.(check string) test_name expected actual
+      in
+      (test_name, `Quick, test_fun)
+    in
+    [
+      make_test ~name:"Rewrites root" ~value:"file:///home/a/something_local"
+        ~opam_monorepo_cwd:"/home/a"
+        ~expected:"file://$OPAM_MONOREPO_CWD/something_local";
+      make_test ~name:"Rewrites vcs root"
+        ~value:"git+file:///home/a/something_local" ~opam_monorepo_cwd:"/home/a"
+        ~expected:"git+file://$OPAM_MONOREPO_CWD/something_local";
+      make_test ~name:"Does not rewrite remote"
+        ~value:"https:///home/a/something.com" ~opam_monorepo_cwd:"/home/a"
+        ~expected:"https:///home/a/something.com";
+      make_test ~name:"Does not rewrite non root"
+        ~value:"file:///house/home/a/something" ~opam_monorepo_cwd:"/home/a"
+        ~expected:"file:///house/home/a/something";
+    ]
+end
+
 module Opam_repositories = struct
   let test_from_opam_value =
-    let make_test ~name ?(opam_monorepo_cwd = "") ~value ~expected () =
+    let make_test ~name ~value ~expected () =
       let test_name =
         Printf.sprintf "Opam_repositories.from_opam_value: %s" name
       in
@@ -34,8 +121,7 @@ module Opam_repositories = struct
               OpamUrl.Set.of_list (List.map ~f:OpamUrl.of_string l))
         in
         let actual =
-          let open Duniverse_lib.Source_opam_config in
-          Private.Opam_repositories.from_opam_value ~opam_monorepo_cwd value
+          Source_opam_config.Private.Opam_repositories.from_opam_value value
         in
         Alcotest.(check (result opam_url_set Testable.r_msg))
           test_name expected actual
@@ -49,35 +135,10 @@ module Opam_repositories = struct
       make_test ~name:"Multiple" ~value:{|[ "https://a.com" "https://b.com" ]|}
         ~expected:(Ok [ "https://a.com"; "https://b.com" ])
         ();
-      make_test ~name:"Rewrites root" ~opam_monorepo_cwd:"/home/a"
-        ~value:{|[ "file://$OPAM_MONOREPO_CWD/something_local" ]|}
-        ~expected:(Ok [ "file:///home/a/something_local" ])
-        ();
-      make_test ~name:"Rewrites vcs root" ~opam_monorepo_cwd:"/home/a"
-        ~value:{|[ "git+file://$OPAM_MONOREPO_CWD/something_local" ]|}
-        ~expected:(Ok [ "git+file:///home/a/something_local" ])
-        ();
-      make_test ~name:"Does not rewrite remote" ~opam_monorepo_cwd:"/home/a"
-        ~value:{|[ "https://$OPAM_MONOREPO_CWD/something_local" ]|}
-        ~expected:
-          (Error
-             (`Msg
-               "Error in opam file test.opam, [1:2]-[1:46]: $OPAM_MONOREPO_CWD \
-                can only be used to rewrite the root part of file:// URLs"))
-        ();
-      make_test ~name:"Does not rewrite non root" ~opam_monorepo_cwd:"/home/a"
-        ~value:{|[ "file:///home/$OPAM_MONOREPO_CWD/something_local" ]|}
-        ~expected:
-          (Error
-             (`Msg
-               "Error in opam file test.opam, [1:2]-[1:51]: $OPAM_MONOREPO_CWD \
-                can only be used to rewrite the root part of file:// URLs"))
-        ();
     ]
 
   let test_to_opam_value =
-    let make_test ~name ?(opam_monorepo_cwd = "__WONTMATCH__") ~url_set
-        ~expected () =
+    let make_test ~name ~url_set ~expected () =
       let test_name =
         Printf.sprintf "Opam_repositories.to_opam_value: %s" name
       in
@@ -86,8 +147,7 @@ module Opam_repositories = struct
           OpamUrl.Set.of_list (List.map ~f:OpamUrl.of_string url_set)
         in
         let actual =
-          let open Duniverse_lib.Source_opam_config in
-          Private.Opam_repositories.to_opam_value ~opam_monorepo_cwd url_set
+          Source_opam_config.Private.Opam_repositories.to_opam_value url_set
           |> OpamPrinter.FullPos.value
         in
         Alcotest.(check string) test_name expected actual
@@ -100,22 +160,6 @@ module Opam_repositories = struct
       make_test ~name:"Multiple"
         ~url_set:[ "https://a.com"; "https://b.com" ]
         ~expected:{|["https://a.com" "https://b.com"]|} ();
-      make_test ~name:"Rewrites root"
-        ~url_set:[ "file:///home/a/something_local" ]
-        ~opam_monorepo_cwd:"/home/a"
-        ~expected:{|["file://$OPAM_MONOREPO_CWD/something_local"]|} ();
-      make_test ~name:"Rewrites vcs root"
-        ~url_set:[ "git+file:///home/a/something_local" ]
-        ~opam_monorepo_cwd:"/home/a"
-        ~expected:{|["git+file://$OPAM_MONOREPO_CWD/something_local"]|} ();
-      make_test ~name:"Does not rewrite remote"
-        ~url_set:[ "https:///home/a/something.com" ]
-        ~opam_monorepo_cwd:"/home/a"
-        ~expected:{|["https:///home/a/something.com"]|} ();
-      make_test ~name:"Does not rewrite non root"
-        ~url_set:[ "file:///house/home/a/something" ]
-        ~opam_monorepo_cwd:"/home/a"
-        ~expected:{|["file:///house/home/a/something"]|} ();
     ]
 end
 
@@ -147,8 +191,8 @@ module Opam_global_vars = struct
         ~expected:
           (Error
              (`Msg
-               "Error in opam file test.opam, [1:0]-[1:28]: Env variable var1 \
-                is defined more than once"))
+               "Error in opam file test.opam, [1:0]-[1:28]: Opam global \
+                variable var1 is defined more than once"))
         ();
     ]
 
@@ -175,12 +219,59 @@ module Opam_global_vars = struct
     ]
 end
 
+module Opam_provided = struct
+  let t_from_input l =
+    List.map ~f:OpamPackage.Name.of_string l |> OpamPackage.Name.Set.of_list
+
+  let test_from_opam_value =
+    let make_test ~name ~value ~expected =
+      let test_name = Printf.sprintf "Opam_provided.from_opam_value: %s" name in
+      let test_fun () =
+        let open Source_opam_config in
+        let value = OpamParser.FullPos.value_from_string value "test.opam" in
+        let expected = Result.map expected ~f:t_from_input in
+        let actual = Private.Opam_provided.from_opam_value value in
+        Alcotest.(check (result pkg_name_set Testable.r_msg))
+          test_name expected actual
+      in
+      (test_name, `Quick, test_fun)
+    in
+    [
+      make_test ~name:"Single" ~value:{|"a"|} ~expected:(Ok [ "a" ]);
+      make_test ~name:"List" ~value:{|["a" "b"]|} ~expected:(Ok [ "a"; "b" ]);
+      make_test ~name:"Error" ~value:{|42|}
+        ~expected:
+          (Rresult.R.error_msg
+             "Error in opam file test.opam, [1:0]-[1:2]: Expected a list or a \
+              string, got: 42");
+    ]
+
+  let test_to_opam_value =
+    let make_test ~name ~value ~expected =
+      let test_name = Printf.sprintf "Opam_provided.to_opam_value: %s" name in
+      let test_fun () =
+        let open Source_opam_config in
+        let value = t_from_input value in
+        let actual =
+          Private.Opam_provided.to_opam_value value |> OpamPrinter.FullPos.value
+        in
+        Alcotest.(check string) test_name expected actual
+      in
+      (test_name, `Quick, test_fun)
+    in
+    [ make_test ~name:"Simple" ~value:[ "a"; "b" ] ~expected:{|["a" "b"]|} ]
+end
+
 let suite =
   ( "Source_opam_config",
     List.concat
       [
+        Opam_repositories_url_rewriter.test_rewrite_one_in;
+        Opam_repositories_url_rewriter.test_rewrite_one_out;
         Opam_repositories.test_from_opam_value;
         Opam_repositories.test_to_opam_value;
         Opam_global_vars.test_from_opam_value;
         Opam_global_vars.test_to_opam_value;
+        Opam_provided.test_from_opam_value;
+        Opam_provided.test_to_opam_value;
       ] )

--- a/test/lib/test_source_opam_config.ml
+++ b/test/lib/test_source_opam_config.ml
@@ -10,17 +10,6 @@ let opam_url_set =
   in
   Alcotest.testable pp OpamUrl.Set.equal
 
-let pkg_name_set =
-  let pp_one fmt pkg_name =
-    Fmt.pf fmt "%S" (OpamPackage.Name.to_string pkg_name)
-  in
-  let pp fmt set =
-    Fmt.pf fmt "[%a]"
-      Fmt.(list ~sep:(const char ';') pp_one)
-      (OpamPackage.Name.Set.elements set)
-  in
-  Alcotest.testable pp OpamPackage.Name.Set.equal
-
 let variable_content_string_map =
   let equal = String.Map.equal ~cmp:( = ) in
   let pp fmt map =
@@ -275,7 +264,7 @@ module Opam_provided = struct
         let value = OpamParser.FullPos.value_from_string value "test.opam" in
         let expected = Result.map expected ~f:t_from_input in
         let actual = Private.Opam_provided.from_opam_value value in
-        Alcotest.(check (result pkg_name_set Testable.r_msg))
+        Alcotest.(check (result Testable.opam_package_name_set Testable.r_msg))
           test_name expected actual
       in
       (test_name, `Quick, test_fun)

--- a/test/lib/testable.ml
+++ b/test/lib/testable.ml
@@ -3,3 +3,7 @@ let r_msg =
       String.equal s s')
 
 let sexp = Alcotest.testable Sexplib0.Sexp.pp Sexplib0.Sexp.equal
+
+let opam_package_name_set =
+  Alcotest.testable Duniverse_lib.Opam.Pp.Package_name_set.pp
+    OpamPackage.Name.Set.equal

--- a/test/lib/testable.mli
+++ b/test/lib/testable.mli
@@ -1,2 +1,3 @@
 val r_msg : Rresult.R.msg Alcotest.testable
 val sexp : Sexplib0.Sexp.t Alcotest.testable
+val opam_package_name_set : OpamPackage.Name.Set.t Alcotest.testable


### PR DESCRIPTION
This PR adds command line arguments to either overwrite or complement `x-opam-monorepo-*` in local opam files.

Each existing field gets a `--<field-name>` option. When this option is passed, its value is used, ignoring local opam files fields.
It also gets a `--add-<field-name>` option to add extra on top of the local opam files fields. It is combined in the same way two fields from different opam files are combined.

It can be useful for experimenting or in certain scenarios where those configuration bits have no natural opam file to be written in.

## Implementation

To be able to do this without writing too much repetitive code I introduced `Serial_shape` which allows to derive both opam and cmdliner parsers and printers from a single value. It simplifies the code of `Source_opam_config` quite a lot.

This required moving the URL rewriting a bit further away from the parsing code but overall it makes things a bit clearer and easier to test.

You'll note the PR comes with an extensive set of tests.