### PR TITLE
Disable filtering of available packages for availability of their depexts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
 
 ### Fixed
 
+- Enable locking of packages with depexts even with uninitialized system
+  package manager state (#322, @Leonidas-from-XIV)
+
 ### Removed
 
 ### Security

--- a/cli/lock.ml
+++ b/cli/lock.ml
@@ -345,6 +345,8 @@ let calculate_opam ~source_config ~build_only ~allow_jbuilder
           let* dependency_entries = dependency_entries in
           Ok (dependency_entries, source_config)
       | { repositories = None; _ } ->
+          let config = OpamFile.Config.with_depext false global_state.config in
+          let global_state = { global_state with config } in
           OpamSwitchState.with_ `Lock_none global_state (fun switch_state ->
               Logs.info (fun l ->
                   l "Solve using current opam switch: %s"


### PR DESCRIPTION
OPAM by default filters out packages for which the system on which it is running does not have the depexts. Which is nice in theory but when building a lockfile we want all packages to be available.

The problem here is that some configurations do not have a queryable package list, e.g. when using Docker containers the package list might have been deleted to save on space in the container, thus `available_packages` would be just a subset and missing packages, despite these existing in the OPAM repositories.

This is the reason why on the Tezos CI it needs `apk update` because if the package list is missing it will just silently exclude a lot of the necessary `conf-*` packages. I tested it locally in a Docker container built in the same way as Tezos where I could reproduce the issue and disabling this in the config makes it work out of the box, without the need for workarounds.